### PR TITLE
Re-adding the capability to exit with an error when a test fails.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -63,6 +63,10 @@ module.exports = function(options) {
   console.time('time elapsed');
   test.run(function(err) {
     console.timeEnd('time elapsed');
-    process.exit(0);
+    if (err && options.failOnError) {
+      process.exit(-1);
+    } else {
+      process.exit(0);
+    }
   });
 };


### PR DESCRIPTION
Currently, the test runner always reports success, even when the
test fail. This renders Travis tests useless as they rely on the
success/failure code to determine build success.
