### PR TITLE
Making two tests not imply order on the result sets.

### DIFF
--- a/interfaces/queryable/findLike.test.js
+++ b/interfaces/queryable/findLike.test.js
@@ -23,8 +23,8 @@ describe('Queryable Interface', function() {
           assert(!err);
           assert(Array.isArray(users));
           assert(users.length === 2, util.format('expected 2 users, but got %s, see?\n%s', users.length, util.inspect(users, false, null) ));
-          assert(users[0].first_name === testName);
-          assert(users[1].first_name === testName2);
+          assert((users[0].first_name === testName && users[1].first_name === testName2) ||
+                 (users[0].first_name === testName2 && users[1].first_name === testName))
           done();
         });
       });

--- a/interfaces/semantic/update.test.js
+++ b/interfaces/semantic/update.test.js
@@ -62,7 +62,8 @@ describe('Semantic Interface', function() {
        Semantic. User.update({ type: 'update' }, { last_name: 'updated again' }).exec(function(err, users) {
           assert(!err);
           assert(users[0].id);
-          assert(users[0].fullName() === 'update_user0 updated again');
+          assert(users[0].first_name.indexOf('update_user') === 0);
+          assert(users[0].last_name === 'updated again');
           assert(toString.call(users[0].createdAt) == '[object Date]');
           assert(toString.call(users[0].updatedAt) == '[object Date]');
           done();


### PR DESCRIPTION
These two tests intermittently fail in the sails-postgres integration tests because they imply an order in the result set that is not guaranteed.

This PR and balderdashy/waterline-sequel#16 will allow all balderdashy/sails-postgres integration tests (222, total) to pass against a clean database. The tests do not properly clean up after themselves and will start failing if you run them against a database a few times.
