### PR TITLE
Adds support for mocha chainable methods 

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -49,6 +49,12 @@ module.exports = function(options) {
   var test = new mocha(_.merge({
     timeout: 6000
   }, options.mocha||{}));
+  
+  if (options.mochaChainableMethods){
+    _.forEach(options.mochaChainableMethods, function(arg, method){
+      test[method](arg);
+    });
+  }
 
   // Set Global Placeholders for Ontologies
   global.Associations = {};


### PR DESCRIPTION
In "sails-adapter-boilerplate" [index.js](https://github.com/balderdashy/sails-adapter-boilerplate/blob/master/index.js#L17-L18) it's suggested:

>  If you don't need / can't get to every method, just implement what you have time for.

That's great but the integration tests will probably break which is very annoying (and the sentiment is also shared by other users in balderdashy/sails-adapter-boilerplate#8 and #33).

This change adds support for mocha [chainable methods](https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically#set-options) such as `invert()`. To use this, the adapter developer only needs to add a `mochaChainableMethods` object with keys matching the chainable methods and the values matching the arguments, example:
``` javascript
    // Mocha options
    // reference: https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically
    mocha: {
      reporter: 'spec',
      grep: /escape attribute names to prevent SQL injection|findOrCreateEach/
    },

    mochaChainableMethods: {
      invert: true,
    }
```
With this errors regarding SQL injection attacks and findOrCreateEach will be ignored.