### PR TITLE
40: Add Interface SQL

### DIFF
--- a/interfaces/semantic/find.test.js
+++ b/interfaces/semantic/find.test.js
@@ -70,14 +70,6 @@ describe('Semantic Interface', function() {
       });
     });
 
-    it('should escape attribute names to prevent SQL injection attacks', function(done) {
-      Semantic.User.find({ type: 'find_test', 'first_name`IS NULL OR 1=1 #': 'whatever' }, function(err, users) {
-        assert(err, 'Should have escaped field name and prevented data from being returned (caused an error)');
-        assert(!users || !users.length, 'Should have escaped field name and prevented data from being returned');
-        done();
-      });
-    });
-
     it('should work with no criteria passed in', function(done) {
       Semantic.User.find(function(err, users) {
         assert(!err);

--- a/interfaces/sql/find.test.js
+++ b/interfaces/sql/find.test.js
@@ -1,0 +1,41 @@
+var assert = require('assert'),
+    _ = require('lodash');
+
+describe('SQL Interface', function() {
+
+  describe('.find()', function() {
+
+    /////////////////////////////////////////////////////
+    // TEST SETUP
+    ////////////////////////////////////////////////////
+
+    before(function(done) {
+
+      // Insert 10 Users
+      var users = [];
+
+      for(var i=0; i<10; i++) {
+        users.push({first_name: 'find_user' + i, type: 'find test', age: i*10 });  // include an integer field
+      }
+
+      Sql.User.createEach(users, function(err, users) {
+        if(err) return done(err);
+        done();
+      });
+    });
+
+    /////////////////////////////////////////////////////
+    // TEST METHODS
+    ////////////////////////////////////////////////////
+
+
+    it('should escape attribute names to prevent SQL injection attacks', function(done) {
+      Sql.User.find({ type: 'find_test', 'first_name`IS NULL OR 1=1 #': 'whatever' }, function(err, users) {
+        assert(err, 'Should have escaped field name and prevented data from being returned (caused an error)');
+        assert(!users || !users.length, 'Should have escaped field name and prevented data from being returned');
+        done();
+      });
+    });
+
+  });
+});

--- a/interfaces/sql/query.test.js
+++ b/interfaces/sql/query.test.js
@@ -1,0 +1,40 @@
+var assert = require('assert'),
+    _ = require('lodash');
+
+describe('SQL Interface', function() {
+
+  describe('.query()', function() {
+
+    /////////////////////////////////////////////////////
+    // TEST SETUP
+    ////////////////////////////////////////////////////
+
+    before(function(done) {
+
+      // Insert 1 User
+      Sql.User.create({first_name: 'query_user', type: 'query test', age: 10 }, function(err, user) {
+        if(err) return done(err);
+        done();
+      });
+    });
+
+    /////////////////////////////////////////////////////
+    // TEST METHODS
+    ////////////////////////////////////////////////////
+    
+    it('should have method .query()', function(done) {
+      assert(Sql.User.query);
+      assert(_.isFunction(Sql.User.query));
+      done();
+    });
+
+    it('should return non undefined result', function(done) {
+      Sql.User.query('SELECT * FROM userTableSql', undefined, function(err, users) {
+        assert(!err);
+        assert(users);
+        done();
+      });
+    });
+
+  });
+});

--- a/interfaces/sql/support/bootstrap.js
+++ b/interfaces/sql/support/bootstrap.js
@@ -1,0 +1,62 @@
+/**
+ * Module Dependencies
+ */
+
+var Waterline = require('waterline');
+var _ = require('lodash');
+var async = require('async');
+var assert = require('assert');
+
+// Require Fixtures
+var fixtures = {
+  UserFixture: require('./fixtures/crud.fixture')
+};
+
+
+/////////////////////////////////////////////////////
+// TEST SETUP
+////////////////////////////////////////////////////
+
+var waterline, ontology;
+
+before(function(done) {
+
+  waterline = new Waterline();
+
+  Object.keys(fixtures).forEach(function(key) {
+    waterline.loadCollection(fixtures[key]);
+  });
+
+  var connections = { sql: _.clone(Connections.test) };
+
+  waterline.initialize({ adapters: { wl_tests: Adapter }, connections: connections }, function(err, _ontology) {
+    if(err) return done(err);
+
+    ontology = _ontology;
+
+    Object.keys(_ontology.collections).forEach(function(key) {
+      var globalName = key.charAt(0).toUpperCase() + key.slice(1);
+      global.Sql[globalName] = _ontology.collections[key];
+    });
+
+    done();
+  });
+});
+
+after(function(done) {
+
+  function dropCollection(item, next) {
+    if(!Adapter.hasOwnProperty('drop')) return next();
+
+    ontology.collections[item].drop(function(err) {
+      if(err) return next(err);
+      next();
+    });
+  }
+
+  async.each(Object.keys(ontology.collections), dropCollection, function(err) {
+    if(err) return done(err);
+    waterline.teardown(done);
+  });
+
+});

--- a/interfaces/sql/support/fixtures/crud.fixture.js
+++ b/interfaces/sql/support/fixtures/crud.fixture.js
@@ -1,0 +1,45 @@
+/**
+ * Dependencies
+ */
+
+var Waterline = require('waterline');
+
+module.exports = Waterline.Collection.extend({
+
+  identity: 'user',
+  tableName: 'userTableSql',
+  connection: 'sql',
+
+  attributes: {
+    first_name: 'string',
+    last_name: 'string',
+    email: {
+      type: 'string',
+      columnName: 'emailAddress'
+    },
+    avatar: 'binary',
+    title: 'string',
+    phone: 'string',
+    type: 'string',
+    favoriteFruit: {
+      defaultsTo: 'blueberry',
+      type: 'string'
+    },
+    age: 'integer', // integer field that's not auto-incrementable
+    dob: 'datetime',
+    status: {
+      type: 'boolean',
+      defaultsTo: false
+    },
+    percent: 'float',
+    list: {
+      type: 'array',
+      columnName: 'arrList'
+    },
+    obj: 'json',
+    fullName: function() {
+      return this.first_name + ' ' + this.last_name;
+    }
+  }
+
+});

--- a/lib/index.js
+++ b/lib/index.js
@@ -61,9 +61,10 @@ module.exports = function(options) {
   global.Semantic = {};
   global.Queryable = {};
   global.Migratable = {};
+  global.Sql = {};
 
   // Allow Adapter to be a global without warning about a leak
-  test.globals([Adapter, Connections, Associations, Semantic, Queryable]);
+  test.globals([Adapter, Connections, Associations, Semantic, Queryable, Sql]);
   test.files = files;
 
   console.time('time elapsed');


### PR DESCRIPTION
As described in issue #40 (discussion and details there) create a new SQL interface to:
* Move SQL injection test to this interface;
* Enforce the existence of `.query()` method in adapters implementing this interface.

This fixes the breaking builds of sails-memory and sails-disk: https://travis-ci.org/balderdashy/waterline-adapter-tests/jobs/56222494#L445 and also clears the broken test *Semantic Interface .find() should escape attribute names to prevent SQL injection attacks.* from sails-mongo and sails-redis builds.

Once this change is merged, this is how the overall test scenario will look like:
```
 ------------------------------------------------------------------- 
| adapter          | version | status  | failed | total | wl-sequel |
|------------------|---------|---------|--------|-------|-----------|
| sails-postgresql | fbbe1c6 | success |      0 |   222 |     0.1.1 |
| sails-memory     | 7cf3600 | success |      0 |   202 |           |
| sails-disk       | 7e09b27 | success |      0 |   202 |           |
| sails-mongo      | 414d748 | failed  |      5 |   201 |           |
| sails-mysql      | 802ccb1 | success |      0 |   223 |     0.1.1 |
| sails-redis      | 6eb8f92 | failed  |      1 |     1 |           |
 ------------------------------------------------------------------- 
```