### PR TITLE
Remove order assumption from populate test.

### DIFF
--- a/interfaces/associations/belongsTo/find.populate.js
+++ b/interfaces/associations/belongsTo/find.populate.js
@@ -47,7 +47,7 @@ describe('Association Interface', function() {
       ////////////////////////////////////////////////////
 
       it('should return customer when the populate criteria is added', function(done) {
-        Associations.Payment.find({ type: 'belongsTo find' })
+        Associations.Payment.find({ type: 'belongsTo find', sort: 'amount ASC' })
         .populate('customer')
         .exec(function(err, _payments) {
           assert(!err, err);


### PR DESCRIPTION
The populate test falsely supposed an order that the records would be inserted and retrieved.  This removes that assumption, allowing sails-mysql tests to pass (fixes https://github.com/balderdashy/sails-mysql/issues/202).