### PR TITLE
Remove same-name association/collection assumption.

### DIFF
--- a/interfaces/associations/belongsTo/create.js
+++ b/interfaces/associations/belongsTo/create.js
@@ -25,9 +25,9 @@ describe('Association Interface', function() {
       ////////////////////////////////////////////////////
 
       it('should create a foreign key value when passed an association key', function(done) {
-        Associations.Payment.create({ amount: 1, customer: customerId }).exec(function(err, payment) {
+        Associations.Payment.create({ amount: 1, a_customer: customerId }).exec(function(err, payment) {
           assert(!err);
-          assert(payment.customer.toString() === customerId.toString());
+          assert(payment.a_customer.toString() === customerId.toString());
           done();
         });
       });

--- a/interfaces/associations/belongsTo/dynamicFinder.js
+++ b/interfaces/associations/belongsTo/dynamicFinder.js
@@ -34,26 +34,26 @@ describe('Association Interface', function() {
       ////////////////////////////////////////////////////
 
       it('should return customer when the dynamic finder method is used for findOne', function(done) {
-        Associations.Payment.findOneByCustomer(customerRecord.id)
+        Associations.Payment.findOneByA_customer(customerRecord.id)
         .exec(function(err, payment) {
           assert(!err);
 
-          assert(payment.customer);
-          assert(payment.customer.id === customerRecord.id);
-          assert(payment.customer.name === 'foobar');
+          assert(payment.a_customer);
+          assert(payment.a_customer.id === customerRecord.id);
+          assert(payment.a_customer.name === 'foobar');
 
           done();
         });
       });
 
       it('should return customer when the dynamic finder method is used for find', function(done) {
-        Associations.Payment.findByCustomer(customerRecord.id)
+        Associations.Payment.findByA_customer(customerRecord.id)
         .exec(function(err, payments) {
           assert(!err);
 
-          assert(payments[0].customer);
-          assert(payments[0].customer.id === customerRecord.id);
-          assert(payments[0].customer.name === 'foobar');
+          assert(payments[0].a_customer);
+          assert(payments[0].a_customer.id === customerRecord.id);
+          assert(payments[0].a_customer.name === 'foobar');
 
           done();
         });

--- a/interfaces/associations/belongsTo/find.populate.js
+++ b/interfaces/associations/belongsTo/find.populate.js
@@ -25,11 +25,11 @@ describe('Association Interface', function() {
         Associations.Payment.createEach([{
             amount: 1,
             type: 'belongsTo find',
-            customer: customers[0].id
+            a_customer: customers[0].id
           }, {
             amount: 2,
             type: 'belongsTo find',
-            customer: customers[1].id
+            a_customer: customers[1].id
           }], function(err, _payments) {
           if(err) return done(err);
 
@@ -46,29 +46,29 @@ describe('Association Interface', function() {
       // TEST METHODS
       ////////////////////////////////////////////////////
 
-      it('should return customer when the populate criteria is added', function(done) {
+      it('should return a customer when the populate criteria is added', function(done) {
         Associations.Payment.find({ type: 'belongsTo find', sort: 'amount ASC' })
-        .populate('customer')
+        .populate('a_customer')
         .exec(function(err, _payments) {
           assert(!err, err);
 
           assert(Array.isArray(_payments));
           assert(_payments.length === 2, 'expected 2 payments, but got '+_payments.length+': '+require('util').inspect(_payments, false, null));
 
-          assert(_payments[0].customer);
-          assert(_payments[0].customer.id === customers[0].id);
-          assert(_payments[0].customer.name === 'foo',
-          'Expected `payments[0].customer.name`==="foo", instead payments[0].customer ===> '+ require('util').inspect(_payments[0].customer, false, null));
+          assert(_payments[0].a_customer);
+          assert(_payments[0].a_customer.id === customers[0].id);
+          assert(_payments[0].a_customer.name === 'foo',
+          'Expected `payments[0].a_customer.name`==="foo", instead payments[0].customer ===> '+ require('util').inspect(_payments[0].a_customer, false, null));
 
-          assert(_payments[1].customer);
-          assert(_payments[1].customer.id === customers[1].id,
-          'Expected `payments[1].customer.id` === '+customers[1].id+', instead payments[1].customer ===> '+ require('util').inspect(_payments[1].customer, false, null));
-          assert(_payments[1].customer.name === 'bar',
-          'Expected `payments[1].customer.name` === "bar", instead payments[1].customer ===> '+ require('util').inspect(_payments[1].customer, false, null)
+          assert(_payments[1].a_customer);
+          assert(_payments[1].a_customer.id === customers[1].id,
+          'Expected `payments[1].a_customer.id` === '+customers[1].id+', instead payments[1].a_customer ===> '+ require('util').inspect(_payments[1].a_customer, false, null));
+          assert(_payments[1].a_customer.name === 'bar',
+          'Expected `payments[1].a_customer.name` === "bar", instead payments[1].a_customer ===> '+ require('util').inspect(_payments[1].a_customer, false, null)
           );
 
-          assert(!_payments[0].toJSON().customer.name,
-          'Expected payments[0] to have `customer` populated with a `name`, but instead it looks like: '+require('util').inspect(_payments[0], false, null)
+          assert(!_payments[0].toJSON().a_customer.name,
+          'Expected payments[0] to have `a_customer` populated with a `name`, but instead it looks like: '+require('util').inspect(_payments[0], false, null)
           );
 
           done();
@@ -80,8 +80,8 @@ describe('Association Interface', function() {
         .exec(function(err, payments) {
           assert(!err);
 
-          assert(!_.isPlainObject(payments[0].customer));
-          assert(!_.isPlainObject(payments[1].customer));
+          assert(!_.isPlainObject(payments[0].a_customer));
+          assert(!_.isPlainObject(payments[1].a_customer));
 
           done();
         });
@@ -89,16 +89,16 @@ describe('Association Interface', function() {
 
       it('should call toJSON on associated record', function(done) {
         Associations.Payment.find()
-        .populate('customer')
+        .populate('a_customer')
         .exec(function(err, payments) {
           assert(!err);
 
           var obj = payments[0].toJSON();
 
           assert(!obj.type);
-          assert(obj.customer);
-          assert(obj.customer.createdAt);
-          assert(!obj.customer.name);
+          assert(obj.a_customer);
+          assert(obj.a_customer.createdAt);
+          assert(!obj.a_customer.name);
 
           done();
         });

--- a/interfaces/associations/belongsTo/findOne.populate.js
+++ b/interfaces/associations/belongsTo/findOne.populate.js
@@ -15,7 +15,7 @@ describe('Association Interface', function() {
       Associations.Customer.create({ name: 'foobar' }, function(err, customer) {
         if(err) return done(err);
 
-        Associations.Payment.create({ amount: 1, customer: customer.id }, function(err, payment) {
+        Associations.Payment.create({ amount: 1, a_customer: customer.id }, function(err, payment) {
           if(err) return done(err);
 
           // Cache customer and payment
@@ -35,13 +35,13 @@ describe('Association Interface', function() {
 
       it('should return customer when the populate criteria is added', function(done) {
         Associations.Payment.findOne({ id: paymentRecord.id })
-        .populate('customer')
+        .populate('a_customer')
         .exec(function(err, payment) {
           assert(!err);
 
-          assert(payment.customer);
-          assert(payment.customer.id === customerRecord.id);
-          assert(payment.customer.name === 'foobar');
+          assert(payment.a_customer);
+          assert(payment.a_customer.id === customerRecord.id);
+          assert(payment.a_customer.name === 'foobar');
 
           done();
         });
@@ -52,7 +52,7 @@ describe('Association Interface', function() {
         .exec(function(err, payment) {
           assert(!err);
 
-          assert(!_.isPlainObject(payment.customer));
+          assert(!_.isPlainObject(payment.a_customer));
 
           done();
         });
@@ -60,16 +60,16 @@ describe('Association Interface', function() {
 
       it('should call toJSON on associated record', function(done) {
         Associations.Payment.findOne({ id: paymentRecord.id })
-        .populate('customer')
+        .populate('a_customer')
         .exec(function(err, payment) {
           assert(!err);
 
           var obj = payment.toJSON();
 
           assert(!obj.type);
-          assert(obj.customer);
-          assert(obj.customer.createdAt);
-          assert(!obj.customer.name);
+          assert(obj.a_customer);
+          assert(obj.a_customer.createdAt);
+          assert(!obj.a_customer.name);
 
           done();
         });

--- a/interfaces/associations/belongsTo/update.nested.js
+++ b/interfaces/associations/belongsTo/update.nested.js
@@ -34,7 +34,7 @@ describe('Association Interface', function() {
 
             var data = {
               amount: 200,
-              customer: {
+              a_customer: {
                 name: 'belongsTo nested update'
               }
             };
@@ -43,10 +43,10 @@ describe('Association Interface', function() {
               assert(!err);
 
               Associations.Payment.findOne(payment[0].id)
-              .populate('customer')
+              .populate('a_customer')
               .exec(function(err, paymnt) {
                 assert(!err);
-                assert(paymnt.customer.name === 'belongsTo nested update');
+                assert(paymnt.a_customer.name === 'belongsTo nested update');
                 done();
               });
             });
@@ -66,7 +66,7 @@ describe('Association Interface', function() {
 
             var data = {
               amount: 200,
-              customer: {
+              a_customer: {
                 name: 'belongsTo nested update'
               }
             };
@@ -88,7 +88,7 @@ describe('Association Interface', function() {
 
             var data = {
               amount: 100,
-              customer: {
+              a_customer: {
                 name: 'belongsTo nested update - updated'
               }
             };
@@ -98,12 +98,12 @@ describe('Association Interface', function() {
 
               // Look up the payment again to be sure the new customer was added
               Associations.Payment.findOne(Payment.id)
-              .populate('customer')
+              .populate('a_customer')
               .exec(function(err, model) {
                 assert(!err);
                 assert(model.amount === 100);
-                assert(model.customer);
-                assert(model.customer.name === 'belongsTo nested update - updated');
+                assert(model.a_customer);
+                assert(model.a_customer.name === 'belongsTo nested update - updated');
                 done();
               });
 
@@ -125,7 +125,7 @@ describe('Association Interface', function() {
               if(err) return done(err);
               Customers = customers;
 
-              Associations.Payment.create({ amount: 100, customer: customers[0].id })
+              Associations.Payment.create({ amount: 100, a_customer: customers[0].id })
               .exec(function(err, payment) {
                 if(err) return done(err);
                 Payment = payment;
@@ -143,7 +143,7 @@ describe('Association Interface', function() {
 
             var data = {
               amount: 200,
-              customer: Customers[1]
+              a_customer: Customers[1]
             };
 
             Associations.Payment.update({ id: Payment.id }, data).exec(function(err, values) {
@@ -151,12 +151,12 @@ describe('Association Interface', function() {
 
               // Look up the payment again to be sure the customer was linked
               Associations.Payment.findOne(values[0].id)
-              .populate('customer')
+              .populate('a_customer')
               .exec(function(err, model) {
                 assert(!err);
 
                 assert(model.amount === 200);
-                assert(model.customer.name === 'bar');
+                assert(model.a_customer.name === 'bar');
 
                 done();
               });

--- a/interfaces/associations/find.associations.test.js
+++ b/interfaces/associations/find.associations.test.js
@@ -27,8 +27,8 @@ describe('Association Interface', function() {
         payments = [];
         var i = 0;
 
-        for(i=0; i<2; i++) payments.push({ amount: i, customer: customers[0].id });
-        for(i=0; i<2; i++) payments.push({ amount: i, customer: customers[1].id });
+        for(i=0; i<2; i++) payments.push({ amount: i, a_customer: customers[0].id });
+        for(i=0; i<2; i++) payments.push({ amount: i, a_customer: customers[1].id });
 
         Associations.Payment.createEach(payments, function(err) {
           if(err) return done(err);

--- a/interfaces/associations/hasMany/add.js
+++ b/interfaces/associations/hasMany/add.js
@@ -19,7 +19,7 @@ describe('Association Interface', function() {
             if(err) return done(err);
 
             customer = model;
-            Associations.Payment.create({ amount: 1, customer: customer.id }, done);
+            Associations.Payment.create({ amount: 1, a_customer: customer.id }, done);
           });
         });
 
@@ -65,7 +65,7 @@ describe('Association Interface', function() {
             if(err) return done(err);
 
             customer = models[0];
-            Associations.Payment.create({ amount: 1, customer: models[1].id }, function(err, paymentModel) {
+            Associations.Payment.create({ amount: 1, a_customer: models[1].id }, function(err, paymentModel) {
               if(err) return done(err);
 
               payment = paymentModel;

--- a/interfaces/associations/hasMany/find.populate.js
+++ b/interfaces/associations/hasMany/find.populate.js
@@ -31,8 +31,8 @@ describe('Association Interface', function() {
           // Create 8 payments, 4 from one customer, 4 from another
           var payments = [];
           for(var i=0; i<8; i++) {
-            if(i < 4) payments.push({ amount: i, customer: customers[0].id });
-            if(i >= 4) payments.push({ amount: i, customer: customers[1].id });
+            if(i < 4) payments.push({ amount: i, a_customer: customers[0].id });
+            if(i >= 4) payments.push({ amount: i, a_customer: customers[1].id });
           }
 
           Associations.Payment.createEach(payments, function(err, payments) {

--- a/interfaces/associations/hasMany/find.populate.where.js
+++ b/interfaces/associations/hasMany/find.populate.where.js
@@ -36,8 +36,8 @@ describe('Association Interface', function() {
           var payments = [];
 
           for(var i=0; i<8; i++) {
-            if(i < 4) payments.push({ amount: i, customer: customers[0].id });
-            if(i >= 4) payments.push({ amount: i, customer: customers[1].id });
+            if(i < 4) payments.push({ amount: i, a_customer: customers[0].id });
+            if(i >= 4) payments.push({ amount: i, a_customer: customers[1].id });
           }
 
           Associations.Payment.createEach(payments, function(err, payments) {
@@ -115,7 +115,7 @@ describe('Association Interface', function() {
       it('should allow filtering by primary key', function(done) {
 
         // Find the payments
-        Associations.Payment.findOne({ amount: 1, customer: Customer.id }).exec(function(err, payment) {
+        Associations.Payment.findOne({ amount: 1, a_customer: Customer.id }).exec(function(err, payment) {
           if(err) return done(err);
 
           Associations.Customer.find({ name: 'hasMany find where' })

--- a/interfaces/associations/hasMany/findOne.populate.js
+++ b/interfaces/associations/hasMany/findOne.populate.js
@@ -20,7 +20,7 @@ describe('Association Interface', function() {
         var payments = [];
 
         for(var i=0; i<4; i++) {
-          payments.push({ amount: i, customer: customer.id });
+          payments.push({ amount: i, a_customer: customer.id });
         }
 
         Associations.Payment.createEach(payments, function(err) {

--- a/interfaces/associations/support/fixtures/hasMany.child.fixture.js
+++ b/interfaces/associations/support/fixtures/hasMany.child.fixture.js
@@ -17,7 +17,7 @@ module.exports = Waterline.Collection.extend({
       model: 'apartment',
       columnName: 'apartment_id'
     },
-    customer: {
+    a_customer: {
       model: 'Customer',
       columnName: 'customer_id'
     },

--- a/interfaces/associations/support/fixtures/hasMany.parent.fixture.js
+++ b/interfaces/associations/support/fixtures/hasMany.parent.fixture.js
@@ -15,7 +15,7 @@ module.exports = Waterline.Collection.extend({
     title: 'string',
     payments: {
       collection: 'Payment',
-      via: 'customer'
+      via: 'a_customer'
     },
 
     toJSON: function() {


### PR DESCRIPTION
The assumption made by these tests that an association's attribute name and collection name are the same covered-up a bug in waterline (https://github.com/balderdashy/waterline/issues/533 / https://github.com/balderdashy/waterline/issues/930).  I think I've properly adjusted the model definitions for hasMany and belongsTo tests so that these bugs are exposed.  I'd love another set of eyes to go over this, though!

PR for proposed fix: https://github.com/balderdashy/waterline/issues/934