### PR TITLE
Make sql interface query test less opinionated.

### DIFF
--- a/interfaces/sql/query.test.js
+++ b/interfaces/sql/query.test.js
@@ -29,7 +29,7 @@ describe('SQL Interface', function() {
     });
 
     it('should return non undefined result', function(done) {
-      Sql.User.query('SELECT * FROM userTableSql', undefined, function(err, users) {
+      Sql.User.query('SELECT * FROM usertablesql', undefined, function(err, users) {
         assert(!err);
         assert(users);
         done();

--- a/interfaces/sql/support/fixtures/crud.fixture.js
+++ b/interfaces/sql/support/fixtures/crud.fixture.js
@@ -7,7 +7,7 @@ var Waterline = require('waterline');
 module.exports = Waterline.Collection.extend({
 
   identity: 'user',
-  tableName: 'userTableSql',
+  tableName: 'usertablesql',
   connection: 'sql',
 
   attributes: {


### PR DESCRIPTION
This should allow https://github.com/balderdashy/sails-postgresql/pull/145 to pass.  Cased table names are dealt with differently in different types of SQL DBs.