### PR TITLE
Force migrate 'alter' on tests

### DIFF
--- a/interfaces/semantic/support/bootstrap.js
+++ b/interfaces/semantic/support/bootstrap.js
@@ -28,8 +28,10 @@ before(function(done) {
   });
 
   var connections = { semantic: _.clone(Connections.test) };
+  
+  var defaults = { migrate: 'alter' };
 
-  waterline.initialize({ adapters: { wl_tests: Adapter }, connections: connections }, function(err, _ontology) {
+  waterline.initialize({ adapters: { wl_tests: Adapter }, connections: connections, defaults: defaults }, function(err, _ontology) {
     if(err) return done(err);
 
     ontology = _ontology;


### PR DESCRIPTION
Force default `migrate: 'alter'` so it's independent from waterline core's default: balderdashy/waterline#887


Addresses balderdashy/waterline#887