### PR TITLE
Ensure nested updates actually updates the child records

### DIFF
--- a/interfaces/associations/belongsTo/update.nested.js
+++ b/interfaces/associations/belongsTo/update.nested.js
@@ -140,10 +140,13 @@ describe('Association Interface', function() {
           ////////////////////////////////////////////////////
 
           it('should update association values', function(done) {
+            
+            var customer = Customers[1].toObject();
+            customer.name = 'bar - updated';
 
             var data = {
               amount: 200,
-              a_customer: Customers[1]
+              a_customer: customer
             };
 
             Associations.Payment.update({ id: Payment.id }, data).exec(function(err, values) {
@@ -155,8 +158,9 @@ describe('Association Interface', function() {
               .exec(function(err, model) {
                 assert(!err);
 
-                assert(model.amount === 200);
-                assert(model.a_customer.name === 'bar');
+                assert.equal(model.amount, 200);
+                assert.equal(model.a_customer.id, Customers[1].id);
+                assert.equal(model.a_customer.name, 'bar - updated');
 
                 done();
               });

--- a/interfaces/associations/hasMany/update.nested.js
+++ b/interfaces/associations/hasMany/update.nested.js
@@ -168,7 +168,11 @@ describe('Association Interface', function() {
 
             var data = {
               name: '1:m update nested - updated',
-              payments: Payments.map(function(payment) { return payment.toObject(); })
+              payments: Payments.map(function(payment, idx) {
+                var res = payment.toObject();
+                res.amount = (idx + 1) * 10;
+                return res;
+              })
             };
 
             Associations.Customer.update({ id: Customer.id }, data).exec(function(err, values) {
@@ -183,8 +187,10 @@ describe('Association Interface', function() {
                 assert(model.payments.length === 2);
 
                 // Ensure association values were updated
-                assert(model.payments[0].amount === 1);
-                assert(model.payments[1].amount === 2);
+                assert.equal(model.payments[0].id, Payments[0].id);
+                assert.equal(model.payments[0].amount, 10);
+                assert.equal(model.payments[1].id, Payments[1].id);
+                assert.equal(model.payments[1].amount, 20);
 
                 done();
               });

--- a/interfaces/associations/manyToMany/update.nested.js
+++ b/interfaces/associations/manyToMany/update.nested.js
@@ -166,7 +166,11 @@ describe('Association Interface', function() {
 
             var taxiData = {
               name: 'm:m update nested - updated',
-              taxis: Taxis.map(function(taxi) { return taxi.toObject(); })
+              taxis: Taxis.map(function(taxi, idx) {
+                var res = taxi.toObject();
+                res.medallion = (idx + 1) * 10;
+                return res;
+              })
             };
 
             Associations.Driver.update({ id: Driver.id }, taxiData).exec(function(err, values) {
@@ -181,8 +185,10 @@ describe('Association Interface', function() {
                 assert(model.taxis.length === 2);
 
                 // Ensure association values were updated
-                assert(model.taxis[0].medallion === 1);
-                assert(model.taxis[1].medallion === 2);
+                assert.equal(model.taxis[0].id, Taxis[0].id);
+                assert.equal(model.taxis[0].medallion, 10);
+                assert.equal(model.taxis[1].id, Taxis[1].id);
+                assert.equal(model.taxis[1].medallion, 20);
 
                 done();
               });


### PR DESCRIPTION
Investigating balderdashy/waterline#964 made me realise that nested updates in the form of `User.update({id: 1 }, { posts: [ { id: 1, title: 'Test post - updated' }] })` works for 1:1 and 1:m associations but breaks for m:n associations. I'm unsure if this is a waterline core issue or something that needs to be dealt in the adapters but it's something we should look into...

This PR ensures update nested actually updates the child values and this currently breaks on all official adapters.