### PR TITLE
Remove order assumption from breaking MySQL tests

### DIFF
--- a/interfaces/associations/hasMany/create.nested.js
+++ b/interfaces/associations/hasMany/create.nested.js
@@ -29,7 +29,7 @@ describe('Association Interface', function() {
 
               // Look up the customer again to be sure the payments were added
               Associations.Customer.findOne(values.id)
-              .populate('payments')
+              .populate('payments', { sort: 'amount ASC' })
               .exec(function(err, model) {
                 if(err) return done(err);
                 assert(model.payments.length === 2);

--- a/interfaces/associations/hasMany/create.nested.js
+++ b/interfaces/associations/hasMany/create.nested.js
@@ -71,7 +71,7 @@ describe('Association Interface', function() {
 
               // Look up the customer again to be sure the payments were added
               Associations.Customer.findOne(values.id)
-              .populate('payments')
+              .populate('payments', { sort: 'amount ASC' })
               .exec(function(err, model) {
                 assert(!err);
                 assert(model.payments.length === 2);

--- a/interfaces/associations/hasMany/update.nested.js
+++ b/interfaces/associations/hasMany/update.nested.js
@@ -109,7 +109,7 @@ describe('Association Interface', function() {
 
               // Look up the customer again to be sure the payments were added
               Associations.Customer.findOne(values[0].id)
-              .populate('payments')
+              .populate('payments', { sort: 'amount ASC' })
               .exec(function(err, model) {
                 assert(!err);
                 assert(model.name === '1:m update nested - updated');

--- a/interfaces/associations/manyToMany/find.populate.where.js
+++ b/interfaces/associations/manyToMany/find.populate.where.js
@@ -50,7 +50,7 @@ describe('Association Interface', function() {
 
     it('should return taxis using skip and limit', function(done) {
       Associations.Driver.find({ name: 'manymany find where' })
-      .populate('taxis', { skip: 1, limit: 2 })
+      .populate('taxis', { skip: 1, limit: 2, sort: 'medallion ASC' })
       .exec(function(err, drivers) {
         assert(!err);
 


### PR DESCRIPTION
Similar to what @devinivy did in #43 and discussed in https://github.com/balderdashy/waterline/issues/887#issuecomment-95210555:

> the integration tests have 3 new broken sails-mysql tests:
> * Association Interface Has Many Association create nested associations() with single level depth and objects should create a new customer and payment association
> * Association Interface 1:m association :: .update() update nested associations() with single level depth when associations already exist should reset associations with the updated associations
> * Association Interface n:m association :: .find().populate([WHERE]) should return taxis using skip and limit
> 
> Build: https://travis-ci.org/balderdashy/waterline-adapter-tests/jobs/59539534#L565

The above tests falsely supposed an order that the records would be inserted and retrieved. This removes that assumption, allowing sails-mysql tests to pass.

The builds results confirms this works:
```
| sails-mysql      | d289f11 | success |      0 |   230 |     0.3.0 |
```
https://travis-ci.org/balderdashy/waterline-adapter-tests/jobs/59756538#L1713