### PR TITLE
Case insensitivity: added not and greaterThan tests

### DIFF
--- a/interfaces/queryable/caseInsensitive.test.js
+++ b/interfaces/queryable/caseInsensitive.test.js
@@ -87,8 +87,9 @@ describe('Queryable Interface', function() {
       before(function(done) {
 
         var usersArray = [
-          { first_name: 'OTHER THINGS 0', type: 'case sensitivity' },
-          { first_name: 'OTHER THINGS 1', type: 'case sensitivity' },
+          { first_name: 'OTHER THINGS 0', type: 'case sensitivity gt' },
+          { first_name: 'oTHER THINGS 1', type: 'case sensitivity gt' },
+          { first_name: 'OTHER THINGS 2', type: 'case sensitivity gt' },
           { first_name: 'AR)H$daxx', type: 'case sensitivity' },
           { first_name: 'AR)H$daxxy', type: 'case sensitivity' },
           { first_name: '0n3 m0r3 est', type: 'case sensitivity' }
@@ -148,6 +149,30 @@ describe('Queryable Interface', function() {
           done();
         });
       });
+      
+      it('not should work in a case insensitive fashion by default', function(done) {
+        Queryable.User.find({ first_name: { not: 'THEtest', contains: 'Test' }, type: 'case sensitivity'}, function(err, users) {
+          assert(users);
+          assert.equal(users.length, 1);
+          assert.equal(users[0].first_name, 'tHeOtherTest');
+          done();
+        });
+      });
+      
+      it('greaterThan should work in a case insensitive fashion by default', function(done) {
+        Queryable.User.find({ first_name: { greaterThan: 'oTHER THINGS 1'}, type: 'case sensitivity gt'}, function(err, users) {
+          assert(users);
+          assert.equal(users.length, 1);
+          assert.equal(users[0].first_name, 'OTHER THINGS 2');
+          
+          Queryable.User.find({ first_name: { greaterThan: 'OTHER THINGS 0', lessThan: 'OTHER THINGS 2'}, type: 'case sensitivity gt'}, function(err, users) {
+            assert(users);
+            assert.equal(users.length, 1);
+            assert.equal(users[0].first_name, 'oTHER THINGS 1');
+            done();
+          });
+        });
+      });
 
     });
 
@@ -191,6 +216,6 @@ describe('Queryable Interface', function() {
         });
       });
     });
-
+    
   });
 });


### PR DESCRIPTION
Following https://github.com/balderdashy/sails-mongo/pull/260#issuecomment-95739741 we should add case insensitivity tests for query modifier `not` and `greaterThan`. 

Unfortunately sails-postgresql does not pass these tests, so it's probably best we fix it before merging this.

**Do not merge yet, this breaks sails-postgresql tests**: https://travis-ci.org/balderdashy/waterline-adapter-tests/jobs/59856880#L273