### PR TITLE
Update travis.yml to use mongo 2.6.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,12 @@ addons:
 env:
   - DB_USER=postgres DB_PASS=''
 before_script:
+  - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
+  - echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | sudo tee /etc/apt/sources.list.d/mongodb.list
+  - sudo apt-get update
+  - sudo apt-get install -y mongodb-org=2.6.5 mongodb-org-server=2.6.5 mongodb-org-shell=2.6.5 mongodb-org-mongos=2.6.5 mongodb-org-tools=2.6.5
+  - sleep 10 # mongo may not be responded directly. See http://docs.travis-ci.com/user/database-setup/#MongoDB
+  - mongo --version
   - npm install balderdashy/waterline
   - psql -c 'create database sailspg;' -U postgres
   - mysql -e 'create database sails_mysql;'


### PR DESCRIPTION
Following sails-mongo upgrade to use mongo 2.6.5 in balderdashy/sails-mongo#260 we need to update waterline-adapter-tests' .travis.yml to reflect the same changes: https://github.com/balderdashy/sails-mongo/pull/260/files#diff-354f30a63fb0907d4ad57269548329e3R5

And another adapter passes all integration tests :smiley: :
```
| sails-mongo      | 35fcc29 | success |      0 |   209 |           |
```
https://travis-ci.org/balderdashy/waterline-adapter-tests/jobs/60410937#L1792