### PR TITLE
Fix a few sails-mysql false positives by explicitly applying `sort`

### DIFF
--- a/interfaces/associations/manyToMany/update.nested.js
+++ b/interfaces/associations/manyToMany/update.nested.js
@@ -107,8 +107,7 @@ describe('Association Interface', function() {
 
               // Look up the driver again to be sure the taxis were added
               Associations.Driver.findOne(values[0].id)
-              .sort('taxis')
-              .populate('taxis')
+              .populate('taxis', { sort: 'medallion' })
               .exec(function(err, model) {
                 assert(!err, 'Error: ' + err);
                 assert(model.name === 'm:m update nested - updated');

--- a/interfaces/associations/manyToMany/update.nested.js
+++ b/interfaces/associations/manyToMany/update.nested.js
@@ -107,6 +107,7 @@ describe('Association Interface', function() {
 
               // Look up the driver again to be sure the taxis were added
               Associations.Driver.findOne(values[0].id)
+              .sort('taxis')
               .populate('taxis')
               .exec(function(err, model) {
                 assert(!err);

--- a/interfaces/associations/manyToMany/update.nested.js
+++ b/interfaces/associations/manyToMany/update.nested.js
@@ -110,7 +110,7 @@ describe('Association Interface', function() {
               .sort('taxis')
               .populate('taxis')
               .exec(function(err, model) {
-                assert(!err);
+                assert(!err, 'Error: ' + err);
                 assert(model.name === 'm:m update nested - updated');
                 assert(model.taxis.length === 3);
                 assert(model.taxis[0].medallion === 3);

--- a/interfaces/queryable/modifiers/lessThan.modifier.test.js
+++ b/interfaces/queryable/modifiers/lessThan.modifier.test.js
@@ -142,7 +142,7 @@ describe('Queryable Interface', function() {
         ////////////////////////////////////////////////////
 
         it('should return records with lessThanOrEqual key', function(done) {
-          Queryable.User.find({ first_name: testName, age: { lessThanOrEqual: 42 }, sort: { id: 1 }}).sort('age').exec(function(err, users) {
+          Queryable.User.find({ first_name: testName, age: { lessThanOrEqual: 42 }}).sort('age').exec(function(err, users) {
             assert(!err);
             assert(Array.isArray(users));
             assert(users.length === 3);
@@ -152,7 +152,7 @@ describe('Queryable Interface', function() {
         });
 
         it('should return records with symbolic usage <= usage', function(done) {
-          Queryable.User.find({ first_name: testName, age: { '<=': 42 }, sort: { id: 1}}).sort('age').exec(function(err, users) {
+          Queryable.User.find({ first_name: testName, age: { '<=': 42 }}).sort('age').exec(function(err, users) {
             assert(!err);
             assert(Array.isArray(users));
             assert(users.length === 3);


### PR DESCRIPTION
The following tests have occasionally broke in automated builds:
* Queryable Interface Modifiers lessThanOrEqual (<=) integers should return records with lessThanOrEqual key
* Association Interface n:m association :: .update() update nested associations() with single level depth when associations already exist should reset associations with the updated associations

Example: https://travis-ci.org/dmarcelino/waterline-adapter-tests/jobs/60511975#L568

Remove assumption that `.find` will return the results in the same order they were created via waterline.

Similar to #43 and #52.