### PR TITLE
Test that create() returns results in correct order: 2

### DIFF
--- a/interfaces/semantic/create.test.js
+++ b/interfaces/semantic/create.test.js
@@ -59,14 +59,15 @@ describe('Semantic Interface', function() {
       var testName = '.create() with a list, returning values';
       var users = [];
 
-      for(var i=0; i<4; i++) {
+      for(var i=0; i<30; i++) {
         users.push({ first_name: 'test_' + i, type: testName });
       }
       Semantic.User.create(users, function(err, users) {
         assert(!err);
-        assert(users[0].first_name === 'test_0');
-        assert(users[1].first_name === 'test_1');
-        assert(users.length === 4, 'Expecting 4 "users", but actually got '+users.length+': '+require('util').inspect(users, false, null));
+        users.forEach(function(val, idx){
+          assert(users[idx].first_name === 'test_' + idx);
+        });
+        assert(users.length === 30, 'Expecting 30 "users", but actually got '+users.length+': '+require('util').inspect(users, false, null));
         done();
       });
     });

--- a/interfaces/semantic/create.test.js
+++ b/interfaces/semantic/create.test.js
@@ -65,7 +65,7 @@ describe('Semantic Interface', function() {
       Semantic.User.create(users, function(err, users) {
         assert(!err);
         assert(users[0].first_name === 'test_0');
-        assert(users[1].first_name === 'test_3');
+        assert(users[1].first_name === 'test_1');
         assert(users.length === 4, 'Expecting 4 "users", but actually got '+users.length+': '+require('util').inspect(users, false, null));
         done();
       });

--- a/interfaces/semantic/create.test.js
+++ b/interfaces/semantic/create.test.js
@@ -55,6 +55,21 @@ describe('Semantic Interface', function() {
       });
     });
 
+    it('should return rows in the correct order when creating multiple rows', function(done) {
+      var testName = '.create() with a list, returning values';
+      var users = [];
+
+      for(var i=0; i<4; i++) {
+        users.push({ first_name: 'test_' + i, type: testName });
+      }
+      Semantic.User.create(users, function(err, users) {
+        assert(!err)
+        assert(users[0].first_name === 'test_0')
+        assert(users[1].first_name === 'test_1')
+        assert(users.length === 4, 'Expecting 4 "users", but actually got '+users.length+': '+require('util').inspect(users, false, null));
+      });
+    });
+
     describe('overloaded usage of create', function() {
 
       /////////////////////////////////////////////////////

--- a/interfaces/semantic/create.test.js
+++ b/interfaces/semantic/create.test.js
@@ -63,10 +63,11 @@ describe('Semantic Interface', function() {
         users.push({ first_name: 'test_' + i, type: testName });
       }
       Semantic.User.create(users, function(err, users) {
-        assert(!err)
-        assert(users[0].first_name === 'test_0')
-        assert(users[1].first_name === 'test_1')
+        assert(!err);
+        assert(users[0].first_name === 'test_0');
+        assert(users[1].first_name === 'test_1');
         assert(users.length === 4, 'Expecting 4 "users", but actually got '+users.length+': '+require('util').inspect(users, false, null));
+        done();
       });
     });
 

--- a/interfaces/semantic/create.test.js
+++ b/interfaces/semantic/create.test.js
@@ -65,7 +65,7 @@ describe('Semantic Interface', function() {
       Semantic.User.create(users, function(err, users) {
         assert(!err);
         assert(users[0].first_name === 'test_0');
-        assert(users[1].first_name === 'test_1');
+        assert(users[1].first_name === 'test_3');
         assert(users.length === 4, 'Expecting 4 "users", but actually got '+users.length+': '+require('util').inspect(users, false, null));
         done();
       });


### PR DESCRIPTION
This PR continues what @kevinburke did in #27 and changes it to test more records (https://github.com/balderdashy/waterline-adapter-tests/commit/883b47efca7158f552de8c4eedc39ea44b25bc22): original test:
> There's a test that create followed by find() returns results from the database
in the correct order, but no test that the create() callback checks the correct
ordering of results.
> 
> I'm trying to track down the behavior observed in https://github.com/balderdashy/sails-postgresql/issues/128

cc: @devinivy 