### PR TITLE
#22: make tests less opinionated about `id` order

### DIFF
--- a/interfaces/queryable/modifiers/lessThan.modifier.test.js
+++ b/interfaces/queryable/modifiers/lessThan.modifier.test.js
@@ -34,7 +34,7 @@ describe('Queryable Interface', function() {
 
         it('should return records with lessThan key', function(done) {
           Queryable.User.find({ first_name: testName, age: { lessThan: 42 }})
-          .sort('id asc')
+          .sort('age asc')
           .exec(function(err, users) {
             assert(!err);
             assert(Array.isArray(users));
@@ -46,7 +46,7 @@ describe('Queryable Interface', function() {
 
         it('should return records with symbolic usage < usage', function(done) {
           Queryable.User.find({ first_name: testName, age: { '<': 42 }})
-          .sort('id asc')
+          .sort('age asc')
           .exec(function(err, users) {
             assert(!err);
             assert(Array.isArray(users));

--- a/interfaces/queryable/modifiers/not.modifier.test.js
+++ b/interfaces/queryable/modifiers/not.modifier.test.js
@@ -32,7 +32,7 @@ describe('Queryable Interface', function() {
 
       it('should return records with string usage', function(done) {
         Queryable.User.find({ first_name: testName, age: { not: 40 }})
-        .sort('id asc')
+        .sort('age asc')
         .exec(function(err, users) {
           assert(!err);
           assert(Array.isArray(users));
@@ -50,7 +50,7 @@ describe('Queryable Interface', function() {
 
       it('should return records with symbolic usage ! usage', function(done) {
         Queryable.User.find({ first_name: testName, age: { '!': 40 }})
-        .sort('id asc')
+        .sort('age asc')
         .exec(function(err, users) {
           assert(!err);
           assert(Array.isArray(users));
@@ -62,7 +62,7 @@ describe('Queryable Interface', function() {
 
       it('should return records using not comparisons on strings', function(done) {
         Queryable.User.find({ first_name: testName, email: { '!': '41@test.com' }})
-        .sort('id asc')
+        .sort('age asc')
         .exec(function(err, users) {
           assert(!err);
 


### PR DESCRIPTION
Following the footsteps of #43, #52 and #56 remove `sort('id asc')` and replace with another fields as there is no guarantee that `id` expresses the insertion order.

Fixes #22.

cc: @adityamukho, @devinivy 