### PR TITLE
Added a Semantic test for updates when unique attributes are present.

### DIFF
--- a/features/unique/README.md
+++ b/features/unique/README.md
@@ -1,0 +1,18 @@
+Feature: unique
+===============
+
+Enable this test in `package.json` with: `"features": ["unique"]`
+
+Ensures no two records will be allowed with the same value. This is a database level constraint 
+so in most cases a unique index will be created in the underlying data-store.
+
+Usage on Waterline models:
+
+```
+attributes: {
+  username: {
+    type: 'string',
+    unique: true
+  }
+}
+```

--- a/features/unique/core/unique.test.js
+++ b/features/unique/core/unique.test.js
@@ -11,7 +11,7 @@ describe('unique attribute feature', function() {
   var defaults = { migrate: 'alter' };
   var waterline;
 
-  var UniqueFixture = require('./support/unique.fixture.js')
+  var UniqueFixture = require('../support/unique.fixture.js')
   var UniqueModel;
 
   var id0, id1, email0;

--- a/features/unique/support/unique.fixture.js
+++ b/features/unique/support/unique.fixture.js
@@ -1,0 +1,22 @@
+/**
+ * Dependencies
+ */
+
+var Waterline = require('waterline');
+
+module.exports = Waterline.Collection.extend({
+
+  identity: 'unique',
+  tableName: 'uniqueTable',
+  connection: 'uniqueConn',
+
+  attributes: {
+    name: 'string',
+    email: {
+      type: 'string',
+      unique: true
+    },
+    type: 'string'
+  }
+
+});

--- a/features/unique/unique.test.js
+++ b/features/unique/unique.test.js
@@ -1,0 +1,97 @@
+var assert = require('assert');
+var _ = require('lodash');
+
+describe('unique attribute feature', function() {
+
+  /////////////////////////////////////////////////////
+  // TEST SETUP
+  ////////////////////////////////////////////////////
+
+  var Waterline = require('waterline');
+  var defaults = { migrate: 'alter' };
+  var waterline;
+
+  var UniqueFixture = require('./support/unique.fixture.js')
+  var UniqueModel;
+
+  var id0, id1, email0;
+
+
+  before(function(done) {
+    waterline = new Waterline();
+    waterline.loadCollection(UniqueFixture);
+
+    var connections = { uniqueConn: _.clone(Connections.test) };
+
+    waterline.initialize({ adapters: { wl_tests: Adapter }, connections: connections, defaults: defaults }, function(err, ontology) {
+      if(err) return done(err);
+      UniqueModel = ontology.collections['unique'];
+
+      // Insert 3 Records
+      var records = [];
+      for(var i=0; i<3; i++) {
+        records.push({name: 'testUnique' + i, email: 'email' + i, type: 'unique'});
+      }
+
+      UniqueModel.createEach(records, function(err, records) {
+        if(err) return done(err);
+        id0 = records[0].id;
+        id1 = records[1].id;
+        email0 = records[0].email.toString();
+        done();
+      });
+    });
+  });
+
+  after(function(done) {
+    if(!Adapter.hasOwnProperty('drop')) {
+      waterline.teardown(done);
+    } else {
+      UniqueModel.drop(function(err1) {
+        waterline.teardown(function(err2) {
+          return done(err1 || err2);
+        });
+      });
+    }
+  });
+
+
+  /////////////////////////////////////////////////////
+  // TEST METHODS
+  ////////////////////////////////////////////////////
+
+  it('should error when creating with a duplicate value', function(done) {
+    UniqueModel.create({ email: email0 }, function(err, records) {
+      assert(err);
+      assert(!records);
+      UniqueModel.find({type: 'unique'}).exec(function(err, records) {
+        assert(!err);
+        assert.equal(records.length, 3);
+        done();
+      });
+    });
+  });
+
+  it('should error when updating with a duplicate value', function(done) {
+    UniqueModel.update(id1, { email: email0 }).exec(function(err, records) {
+      assert(err);
+      assert(!records);
+      UniqueModel.findOne(id1).exec(function(err, record) {
+        assert(!err);
+        assert.notEqual(record.email, email0);
+        done();
+      });
+    });
+  });
+
+  it('should work (do nothing) when updating a unique field to the same value', function(done) {
+    UniqueModel.update(id0, { email: email0 }).exec(function(err, records) {
+      assert(!err, 'Expected no error when updating to the same value');
+      assert.equal(records.length, 1);
+      assert.equal(records[0].id, id0);
+      assert.equal(records[0].email, email0);
+      done();
+    });
+  });
+
+});

--- a/features/unique/unique.test.js
+++ b/features/unique/unique.test.js
@@ -84,9 +84,19 @@ describe('unique attribute feature', function() {
     });
   });
 
-  it('should work (do nothing) when updating a unique field to the same value', function(done) {
-    UniqueModel.update(id0, { email: email0 }).exec(function(err, records) {
+  it('should work (do nothing) when updating the field of an existing record to the same value', function(done) {
+    UniqueModel.update(id0, { id: id0, name: 'testUnique0', email: email0, type: 'unique' }).exec(function(err, records) {
       assert(!err, 'Expected no error when updating to the same value');
+      assert.equal(records.length, 1);
+      assert.equal(records[0].id, id0);
+      assert.equal(records[0].email, email0);
+      done();
+    });
+  });
+
+  it('should work when updating a unique field to the same value based on search parameters', function(done) {
+    UniqueModel.update({email: email0}, { email: email0 }).exec(function(err, records) {
+      assert(!err, 'Expected no error when updating to the same value on searched records');
       assert.equal(records.length, 1);
       assert.equal(records[0].id, id0);
       assert.equal(records[0].email, email0);

--- a/features/unique/unique.test.js
+++ b/features/unique/unique.test.js
@@ -61,7 +61,7 @@ describe('unique attribute feature', function() {
   ////////////////////////////////////////////////////
 
   it('should error when creating with a duplicate value', function(done) {
-    UniqueModel.create({ email: email0 }, function(err, records) {
+    UniqueModel.create({ email: email0, type: 'unique' }, function(err, records) {
       assert(err);
       assert(!records);
       UniqueModel.find({type: 'unique'}).exec(function(err, records) {


### PR DESCRIPTION
When updating multiple records based on a given *find criteria* there won't be an `id` specified in the object with the new values. This could make it tricky, when a model has attributes marked as `unique`, to establish whether an existing record with a duplicate value is actually the record being updated, which is not actually a violation.

The `sails-memory` adapter has such a bug, and this test was added to flag it. I will reference this PR from the one I submit with the fix for the bug on the `sails-memory` repo.