### PR TITLE
Data Types Testing Issue

### DIFF
--- a/interfaces/semantic/types/array.type.js
+++ b/interfaces/semantic/types/array.type.js
@@ -13,6 +13,8 @@ describe('Semantic Interface', function() {
       it('should store proper array value', function(done) {
         Semantic.User.create({ list: [0,1,2,3] }, function(err, createdRecord) {
           assert(!err);
+          assert(Array.isArray(createdRecord.list));
+          assert(createdRecord.list.length === 4);
           Semantic.User.findOne({id: createdRecord.id}, function (err, record) {
             assert(!err);
             assert(Array.isArray(record.list));

--- a/interfaces/semantic/types/array.type.js
+++ b/interfaces/semantic/types/array.type.js
@@ -11,14 +11,16 @@ describe('Semantic Interface', function() {
       ////////////////////////////////////////////////////
 
       it('should store proper array value', function(done) {
-        Semantic.User.create({ list: [0,1,2,3] }, function(err, record) {
+        Semantic.User.create({ list: [0,1,2,3] }, function(err, createdRecord) {
           assert(!err);
-          assert(Array.isArray(record.list));
-          assert(record.list.length === 4);
-          done();
+          Semantic.User.findOne({id: createdRecord.id}, function (err, record) {
+            assert(!err);
+            assert(Array.isArray(record.list));
+            assert(record.list.length === 4);
+            done();
+          });
         });
       });
-
     });
   });
 });

--- a/interfaces/semantic/types/binary.type.js
+++ b/interfaces/semantic/types/binary.type.js
@@ -22,6 +22,7 @@ describe('Semantic Interface', function() {
         // store the binary thing
         Semantic.User.create({ avatar: buf }, function(err, createdRecord) {
           assert(!err, err);
+          assert(new Buffer(createdRecord.avatar).toString('utf-8') === str);
           Semantic.User.findOne({id: createdRecord.id}, function (err, record) {
               assert(!err);
               // read out the stored binary thing

--- a/interfaces/semantic/types/binary.type.js
+++ b/interfaces/semantic/types/binary.type.js
@@ -20,13 +20,15 @@ describe('Semantic Interface', function() {
         // to make a binary thing
         var buf = new Buffer(str, "utf-8");
         // store the binary thing
-        Semantic.User.create({ avatar: buf }, function(err, record) {
+        Semantic.User.create({ avatar: buf }, function(err, createdRecord) {
           assert(!err, err);
-          // read out the stored binary thing
-          var outbuf = new Buffer(record.avatar);
-          
-          assert(outbuf.toString('utf-8') === str);
-          done();
+          Semantic.User.findOne({id: createdRecord.id}, function (err, record) {
+              assert(!err);
+              // read out the stored binary thing
+              var outbuf = new Buffer(record.avatar);
+              assert(outbuf.toString('utf-8') === str);
+              done();
+           });
         });
       });
 

--- a/interfaces/semantic/types/boolean.type.js
+++ b/interfaces/semantic/types/boolean.type.js
@@ -11,10 +11,13 @@ describe('Semantic Interface', function() {
       ////////////////////////////////////////////////////
 
       it('should store proper boolean value', function(done) {
-        Semantic.User.create({ status: true }, function(err, record) {
+        Semantic.User.create({ status: true }, function (err, createdRecord) {
           assert(!err);
-          assert(record.status === true);
-          done();
+          Semantic.User.findOne({id: createdRecord.id}, function (err, record) {
+            assert(!err);
+            assert(record.status === true);
+            done();
+          });
         });
       });
 

--- a/interfaces/semantic/types/boolean.type.js
+++ b/interfaces/semantic/types/boolean.type.js
@@ -13,6 +13,7 @@ describe('Semantic Interface', function() {
       it('should store proper boolean value', function(done) {
         Semantic.User.create({ status: true }, function (err, createdRecord) {
           assert(!err);
+          assert(createdRecord.status === true);
           Semantic.User.findOne({id: createdRecord.id}, function (err, record) {
             assert(!err);
             assert(record.status === true);

--- a/interfaces/semantic/types/date.type.js
+++ b/interfaces/semantic/types/date.type.js
@@ -12,12 +12,14 @@ describe('Semantic Interface', function() {
 
       it('should store proper date value', function(done) {
         var date = new Date();
+        var origDate = Date.parse(date);
         Semantic.User.create({ dob: date }, function(err, createdRecord) {
           assert(!err);
+          var createdDate = Date.parse(new Date(createdRecord.dob));
+          assert(origDate === createdDate);
           Semantic.User.findOne({id: createdRecord.id}, function (err, record) {
             assert(!err);
             // Convert both dates to unix timestamps
-            var origDate = Date.parse(date);
             var resultDate = Date.parse(new Date(record.dob));
             assert(origDate === resultDate);
             done();

--- a/interfaces/semantic/types/date.type.js
+++ b/interfaces/semantic/types/date.type.js
@@ -12,15 +12,16 @@ describe('Semantic Interface', function() {
 
       it('should store proper date value', function(done) {
         var date = new Date();
-        Semantic.User.create({ dob: date }, function(err, record) {
+        Semantic.User.create({ dob: date }, function(err, createdRecord) {
           assert(!err);
-
-          // Convert both dates to unix timestamps
-          var origDate = Date.parse(date);
-          var resultDate = Date.parse(new Date(record.dob));
-
-          assert(origDate === resultDate);
-          done();
+          Semantic.User.findOne({id: createdRecord.id}, function (err, record) {
+            assert(!err);
+            // Convert both dates to unix timestamps
+            var origDate = Date.parse(date);
+            var resultDate = Date.parse(new Date(record.dob));
+            assert(origDate === resultDate);
+            done();
+          });
         });
       });
 

--- a/interfaces/semantic/types/float.type.js
+++ b/interfaces/semantic/types/float.type.js
@@ -11,10 +11,13 @@ describe('Semantic Interface', function() {
       ////////////////////////////////////////////////////
 
       it('should store proper float value', function(done) {
-        Semantic.User.create({ percent: 0.001 }, function(err, record) {
+        Semantic.User.create({ percent: 0.001 }, function(err, createdRecord) {
           assert(!err);
-          assert(record.percent === 0.001);
-          done();
+          Semantic.User.findOne({id: createdRecord.id}, function(err, record) {
+            assert(!err);
+            assert(record.percent === 0.001);
+            done();
+          });
         });
       });
 

--- a/interfaces/semantic/types/float.type.js
+++ b/interfaces/semantic/types/float.type.js
@@ -13,6 +13,7 @@ describe('Semantic Interface', function() {
       it('should store proper float value', function(done) {
         Semantic.User.create({ percent: 0.001 }, function(err, createdRecord) {
           assert(!err);
+          assert(createdRecord.percent === 0.001);
           Semantic.User.findOne({id: createdRecord.id}, function(err, record) {
             assert(!err);
             assert(record.percent === 0.001);

--- a/interfaces/semantic/types/integer.type.js
+++ b/interfaces/semantic/types/integer.type.js
@@ -11,10 +11,13 @@ describe('Semantic Interface', function() {
       ////////////////////////////////////////////////////
 
       it('should store proper integer', function(done) {
-        Semantic.User.create({ age: 27 }, function(err, record) {
+        Semantic.User.create({ age: 27 }, function (err, createdRecord) {
           assert(!err);
-          assert(record.age === 27);
-          done();
+          Semantic.User.findOne({id: createdRecord.id}, function (err, record) {
+            assert(!err);
+            assert(record.age === 27);
+            done();
+          });
         });
       });
 

--- a/interfaces/semantic/types/integer.type.js
+++ b/interfaces/semantic/types/integer.type.js
@@ -13,6 +13,7 @@ describe('Semantic Interface', function() {
       it('should store proper integer', function(done) {
         Semantic.User.create({ age: 27 }, function (err, createdRecord) {
           assert(!err);
+          assert(createdRecord.age === 27);
           Semantic.User.findOne({id: createdRecord.id}, function (err, record) {
             assert(!err);
             assert(record.age === 27);

--- a/interfaces/semantic/types/json.type.js
+++ b/interfaces/semantic/types/json.type.js
@@ -13,6 +13,8 @@ describe('Semantic Interface', function() {
       it('should store proper object value', function(done) {
         Semantic.User.create({ obj: {foo: 'bar'} }, function(err, createdRecord) {
           assert(!err);
+          assert(createdRecord.obj === Object(createdRecord.obj));
+          assert(createdRecord.obj.foo === 'bar');
           Semantic.User.findOne({id: createdRecord.id}, function (err, record) {
             assert(!err);
             assert(record.obj === Object(record.obj));

--- a/interfaces/semantic/types/json.type.js
+++ b/interfaces/semantic/types/json.type.js
@@ -11,11 +11,14 @@ describe('Semantic Interface', function() {
       ////////////////////////////////////////////////////
 
       it('should store proper object value', function(done) {
-        Semantic.User.create({ obj: {foo: 'bar'} }, function(err, record) {
+        Semantic.User.create({ obj: {foo: 'bar'} }, function(err, createdRecord) {
           assert(!err);
-          assert(record.obj === Object(record.obj));
-          assert(record.obj.foo === 'bar');
-          done();
+          Semantic.User.findOne({id: createdRecord.id}, function (err, record) {
+            assert(!err);
+            assert(record.obj === Object(record.obj));
+            assert(record.obj.foo === 'bar');
+            done();
+          });
         });
       });
 

--- a/interfaces/semantic/types/string.type.js
+++ b/interfaces/semantic/types/string.type.js
@@ -11,10 +11,13 @@ describe('Semantic Interface', function() {
       ////////////////////////////////////////////////////
 
       it('should store proper string value', function(done) {
-        Semantic.User.create({ first_name: 'Foo' }, function(err, record) {
+        Semantic.User.create({ first_name: 'Foo' }, function(err, createdRecord) {
           assert(!err);
-          assert(record.first_name === 'Foo');
-          done();
+          Semantic.User.findOne({id: createdRecord.id}, function (err, record) {
+            assert(!err);
+            assert(record.first_name === 'Foo');
+            done();
+          });
         });
       });
 

--- a/interfaces/semantic/types/string.type.js
+++ b/interfaces/semantic/types/string.type.js
@@ -13,6 +13,7 @@ describe('Semantic Interface', function() {
       it('should store proper string value', function(done) {
         Semantic.User.create({ first_name: 'Foo' }, function(err, createdRecord) {
           assert(!err);
+          assert(createdRecord.first_name === 'Foo');
           Semantic.User.findOne({id: createdRecord.id}, function (err, record) {
             assert(!err);
             assert(record.first_name === 'Foo');


### PR DESCRIPTION
The tests of data types (semantic/types) use the values returned from a .create() call, .create() retrieved only auto incremented ids from the table so the values returned in callback will be the same values passed as parameters, that's why the test should insert, and then query the table to retrieve the persistent value.