### PR TITLE
Travis: falling back to mongo 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,6 @@ addons:
 env:
   - DB_USER=postgres DB_PASS=''
 before_script:
-  - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
-  - echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | sudo tee /etc/apt/sources.list.d/mongodb.list
-  - sudo apt-get update
-  - sudo apt-get install -y mongodb-org=2.6.5 mongodb-org-server=2.6.5 mongodb-org-shell=2.6.5 mongodb-org-mongos=2.6.5 mongodb-org-tools=2.6.5
-  - sleep 10 # mongo may not be responded directly. See http://docs.travis-ci.com/user/database-setup/#MongoDB
-  - mongo --version
   - npm install balderdashy/waterline
   - psql -c 'create database sailspg;' -U postgres
   - mysql -e 'create database sails_mysql;'


### PR DESCRIPTION
Since the build will run quicker as it won't have to install MongoDB 2.6.5.

Surprisingly, applying the same change to sails-mongo's .travis.yml ([branch travis-mongo-2.4](https://github.com/balderdashy/sails-mongo/tree/travis-mongo-2.4)) breaks the build with error:
* Association Interface Has Many Association create nested associations() with single level depth and objects mixed with ids should create a new customer and payment association

https://travis-ci.org/balderdashy/sails-mongo/jobs/61697570#L198

It may be because sails-mongo needs unreleased changed from waterline/waterline-adapter-tests. Anyway, we probably should get to the bottom of that and apply both changes simultaneously so both sails-mongo and integration tests are tested against the same target.