### PR TITLE
30: replace assert(a === b) for assert.equal(a, b)

### DIFF
--- a/interfaces/associations/belongsTo/create.js
+++ b/interfaces/associations/belongsTo/create.js
@@ -27,7 +27,7 @@ describe('Association Interface', function() {
       it('should create a foreign key value when passed an association key', function(done) {
         Associations.Payment.create({ amount: 1, a_customer: customerId }).exec(function(err, payment) {
           assert(!err);
-          assert(payment.a_customer.toString() === customerId.toString());
+          assert.equal(payment.a_customer.toString(), customerId.toString());
           done();
         });
       });

--- a/interfaces/associations/belongsTo/dynamicFinder.js
+++ b/interfaces/associations/belongsTo/dynamicFinder.js
@@ -39,8 +39,8 @@ describe('Association Interface', function() {
           assert(!err);
 
           assert(payment.a_customer);
-          assert(payment.a_customer.id === customerRecord.id);
-          assert(payment.a_customer.name === 'foobar');
+          assert.equal(payment.a_customer.id, customerRecord.id);
+          assert.equal(payment.a_customer.name, 'foobar');
 
           done();
         });
@@ -52,8 +52,8 @@ describe('Association Interface', function() {
           assert(!err);
 
           assert(payments[0].a_customer);
-          assert(payments[0].a_customer.id === customerRecord.id);
-          assert(payments[0].a_customer.name === 'foobar');
+          assert.equal(payments[0].a_customer.id, customerRecord.id);
+          assert.equal(payments[0].a_customer.name, 'foobar');
 
           done();
         });

--- a/interfaces/associations/belongsTo/find.populate.js
+++ b/interfaces/associations/belongsTo/find.populate.js
@@ -53,10 +53,10 @@ describe('Association Interface', function() {
           assert(!err, err);
 
           assert(Array.isArray(_payments));
-          assert(_payments.length === 2, 'expected 2 payments, but got '+_payments.length+': '+require('util').inspect(_payments, false, null));
+          assert.equal(_payments.length, 2, 'expected 2 payments, but got '+_payments.length+': '+require('util').inspect(_payments, false, null));
 
           assert(_payments[0].a_customer);
-          assert(_payments[0].a_customer.id === customers[0].id);
+          assert.equal(_payments[0].a_customer.id, customers[0].id);
           assert(_payments[0].a_customer.name === 'foo',
           'Expected `payments[0].a_customer.name`==="foo", instead payments[0].customer ===> '+ require('util').inspect(_payments[0].a_customer, false, null));
 

--- a/interfaces/associations/belongsTo/findOne.populate.js
+++ b/interfaces/associations/belongsTo/findOne.populate.js
@@ -40,8 +40,8 @@ describe('Association Interface', function() {
           assert(!err);
 
           assert(payment.a_customer);
-          assert(payment.a_customer.id === customerRecord.id);
-          assert(payment.a_customer.name === 'foobar');
+          assert.equal(payment.a_customer.id, customerRecord.id);
+          assert.equal(payment.a_customer.name, 'foobar');
 
           done();
         });

--- a/interfaces/associations/belongsTo/multipleForeignKeys.js
+++ b/interfaces/associations/belongsTo/multipleForeignKeys.js
@@ -32,8 +32,8 @@ describe('Association Interface', function() {
       it('should create multiple foreign key values when passed association keys', function(done) {
         Associations.Payment_many.create({ amount: 1, customer: customer_1_id, patron: customer_2_id }).exec(function(err, payment) {
           assert(!err);
-          assert(payment.customer.toString() === customer_1_id.toString());
-          assert(payment.patron.toString() === customer_2_id.toString());
+          assert.equal(payment.customer.toString(), customer_1_id.toString());
+          assert.equal(payment.patron.toString(), customer_2_id.toString());
           done();
         });
       });
@@ -51,8 +51,8 @@ describe('Association Interface', function() {
             var obj = payment.toJSON();
 
             assert(obj.patron);
-            assert(obj.patron.id.toString() === customer_2_id.toString());
-            assert(obj.customer.toString() === customer_1_id.toString());
+            assert.equal(obj.patron.id.toString(), customer_2_id.toString());
+            assert.equal(obj.customer.toString(), customer_1_id.toString());
 
             done();
           });

--- a/interfaces/associations/belongsTo/update.nested.js
+++ b/interfaces/associations/belongsTo/update.nested.js
@@ -46,7 +46,7 @@ describe('Association Interface', function() {
               .populate('a_customer')
               .exec(function(err, paymnt) {
                 assert(!err);
-                assert(paymnt.a_customer.name === 'belongsTo nested update');
+                assert.equal(paymnt.a_customer.name, 'belongsTo nested update');
                 done();
               });
             });
@@ -101,9 +101,9 @@ describe('Association Interface', function() {
               .populate('a_customer')
               .exec(function(err, model) {
                 assert(!err);
-                assert(model.amount === 100);
+                assert.equal(model.amount, 100);
                 assert(model.a_customer);
-                assert(model.a_customer.name === 'belongsTo nested update - updated');
+                assert.equal(model.a_customer.name, 'belongsTo nested update - updated');
                 done();
               });
 
@@ -155,8 +155,8 @@ describe('Association Interface', function() {
               .exec(function(err, model) {
                 assert(!err);
 
-                assert(model.amount === 200);
-                assert(model.a_customer.name === 'bar');
+                assert.equal(model.amount, 200);
+                assert.equal(model.a_customer.name, 'bar');
 
                 done();
               });

--- a/interfaces/associations/find.associations.test.js
+++ b/interfaces/associations/find.associations.test.js
@@ -56,13 +56,13 @@ describe('Association Interface', function() {
       .exec(function(err, customers) {
         assert(!err);
         assert(Array.isArray(customers));
-        assert(customers.length === 2);
+        assert.equal(customers.length, 2);
 
         assert(Array.isArray(customers[0].payments));
         assert(Array.isArray(customers[1].payments));
 
-        assert(customers[0].payments.length === 2, 'Expected 2 payments, but got customers[0] ==> ' +require('util').inspect(customers[0], false, null));
-        assert(customers[1].payments.length === 2);
+        assert.equal(customers[0].payments.length, 2, 'Expected 2 payments, but got customers[0] ==> ' +require('util').inspect(customers[0], false, null));
+        assert.equal(customers[1].payments.length, 2);
 
         assert.equal(customers[0].payments[0].amount, 0);
         assert.equal(customers[0].payments[1].amount, 1, 'Expected amount of second associated payment to === 1, but instead here is the customer:'+util.inspect(customers[0], false, null));

--- a/interfaces/associations/hasMany/add.js
+++ b/interfaces/associations/hasMany/add.js
@@ -38,8 +38,8 @@ describe('Association Interface', function() {
             .exec(function(err, model) {
               assert(!err);
 
-              assert(model.payments.length === 2);
-              assert(model.payments[1].amount === 1337);
+              assert.equal(model.payments.length, 2);
+              assert.equal(model.payments[1].amount, 1337);
               done();
             });
           });
@@ -89,8 +89,8 @@ describe('Association Interface', function() {
             .exec(function(err, data) {
               assert(!err);
 
-              assert(data.payments.length === 1);
-              assert(data.payments[0].amount === 1);
+              assert.equal(data.payments.length, 1);
+              assert.equal(data.payments[0].amount, 1);
               done();
             });
           });

--- a/interfaces/associations/hasMany/create.nested.js
+++ b/interfaces/associations/hasMany/create.nested.js
@@ -32,8 +32,8 @@ describe('Association Interface', function() {
               .populate('payments', { sort: 'amount ASC' })
               .exec(function(err, model) {
                 if(err) return done(err);
-                assert(model.payments.length === 2);
-                assert(model.payments[1].amount === 2);
+                assert.equal(model.payments.length, 2);
+                assert.equal(model.payments[1].amount, 2);
                 done();
               });
 
@@ -74,8 +74,8 @@ describe('Association Interface', function() {
               .populate('payments', { sort: 'amount ASC' })
               .exec(function(err, model) {
                 assert(!err);
-                assert(model.payments.length === 2);
-                assert(model.payments[1].amount === 2);
+                assert.equal(model.payments.length, 2);
+                assert.equal(model.payments[1].amount, 2);
                 done();
               });
 

--- a/interfaces/associations/hasMany/find.populate.customPK.js
+++ b/interfaces/associations/hasMany/find.populate.customPK.js
@@ -54,13 +54,13 @@ describe('Association Interface', function() {
           assert(!err, err);
 
           assert(Array.isArray(apartments));
-          assert(apartments.length === 2, 'expected 2 apartments, got these apartments:'+require('util').inspect(apartments, false, null));
+          assert.equal(apartments.length, 2, 'expected 2 apartments, got these apartments:'+require('util').inspect(apartments, false, null));
 
           assert(Array.isArray(apartments[0].payments));
           assert(Array.isArray(apartments[1].payments));
 
-          assert(apartments[0].payments.length === 4);
-          assert(apartments[1].payments.length === 4);
+          assert.equal(apartments[0].payments.length, 4);
+          assert.equal(apartments[1].payments.length, 4);
 
           done();
         });

--- a/interfaces/associations/hasMany/find.populate.js
+++ b/interfaces/associations/hasMany/find.populate.js
@@ -56,13 +56,13 @@ describe('Association Interface', function() {
           assert(!err, err);
 
           assert(Array.isArray(customers));
-          assert(customers.length === 2, 'expected 2 customers, got these customers:'+require('util').inspect(customers, false, null));
+          assert.equal(customers.length, 2, 'expected 2 customers, got these customers:'+require('util').inspect(customers, false, null));
 
           assert(Array.isArray(customers[0].payments));
           assert(Array.isArray(customers[1].payments));
 
-          assert(customers[0].payments.length === 4);
-          assert(customers[1].payments.length === 4);
+          assert.equal(customers[0].payments.length, 4);
+          assert.equal(customers[1].payments.length, 4);
 
           done();
         });
@@ -78,11 +78,11 @@ describe('Association Interface', function() {
           assert(!err, err);
 
           assert(Array.isArray(customers));
-          assert(customers.length === 1);
+          assert.equal(customers.length, 1);
 
           assert(Array.isArray(customers[0].payments));
-          assert(customers[0].payments.length === 4, 'Expected customers[0] to have 4 payments, but got '+customers[0].payments.length+'.  Customers: '+require('util').inspect(customers, false, null));
-          assert(customers[0].payments[0].amount === 0);
+          assert.equal(customers[0].payments.length, 4, 'Expected customers[0] to have 4 payments, but got '+customers[0].payments.length+'.  Customers: '+require('util').inspect(customers, false, null));
+          assert.equal(customers[0].payments[0].amount, 0);
 
           done();
         });
@@ -128,10 +128,10 @@ describe('Association Interface', function() {
           assert(!err, err);
 
           assert(Array.isArray(customers));
-          assert(customers.length === 1);
+          assert.equal(customers.length, 1);
 
           assert(Array.isArray(customers[0].payments));
-          assert(customers[0].payments.length === 4);
+          assert.equal(customers[0].payments.length, 4);
           assert(customers[0].payments[0].amount === 4,
             'Expected customers[0].payments[0].amount === 4, but customers[0] ==>\n'+
             util.inspect(customers[0]));
@@ -161,7 +161,7 @@ describe('Association Interface', function() {
           var obj = customers[0].toJSON();
 
           assert(Array.isArray(obj.payments));
-          assert(obj.payments.length === 4);
+          assert.equal(obj.payments.length, 4);
 
           assert(!obj.payments[0].hasOwnProperty('type'));
           assert(!obj.payments[1].hasOwnProperty('type'));

--- a/interfaces/associations/hasMany/find.populate.where.js
+++ b/interfaces/associations/hasMany/find.populate.where.js
@@ -62,7 +62,7 @@ describe('Association Interface', function() {
           assert(!err,err);
 
           assert(Array.isArray(customers));
-          assert(customers.length === 2);
+          assert.equal(customers.length, 2);
 
           assert(Array.isArray(customers[0].payments));
           assert(Array.isArray(customers[1].payments));
@@ -70,10 +70,10 @@ describe('Association Interface', function() {
           assert(customers[0].payments.length === 2,
           'expecting customers[0] to have 2 payments, but actually she looks like: \n'+util.inspect(customers[0],false, null));
 
-          assert(customers[0].payments[0].amount === 0);
-          assert(customers[0].payments[1].amount === 1);
+          assert.equal(customers[0].payments[0].amount, 0);
+          assert.equal(customers[0].payments[1].amount, 1);
 
-          assert(customers[1].payments.length === 0);
+          assert.equal(customers[1].payments.length, 0);
 
           done();
         });
@@ -87,14 +87,14 @@ describe('Association Interface', function() {
           assert(!err);
 
           assert(Array.isArray(customers));
-          assert(customers.length === 2);
+          assert.equal(customers.length, 2);
 
           assert(Array.isArray(customers[0].payments));
           assert(Array.isArray(customers[1].payments));
 
-          assert(customers[0].payments.length === 2);
-          assert(customers[0].payments[0].amount === 1);
-          assert(customers[0].payments[1].amount === 2);
+          assert.equal(customers[0].payments.length, 2);
+          assert.equal(customers[0].payments[0].amount, 1);
+          assert.equal(customers[0].payments[1].amount, 2);
 
           assert(
             customers[1].payments.length === 2,
@@ -106,7 +106,7 @@ describe('Association Interface', function() {
             'expected customers[1].payments[0].amount === 5, but customers[1] ==>\n'+
             util.inspect(customers[1], false, null)
           );
-          assert(customers[1].payments[1].amount === 6);
+          assert.equal(customers[1].payments[1].amount, 6);
 
           done();
         });
@@ -125,14 +125,14 @@ describe('Association Interface', function() {
             assert(!err);
 
             assert(Array.isArray(customers));
-            assert(customers.length === 2);
+            assert.equal(customers.length, 2);
 
             assert(Array.isArray(customers[0].payments));
             assert(Array.isArray(customers[1].payments));
 
-            assert(customers[0].payments.length === 1);
-            assert(customers[0].payments[0].amount === 1);
-            assert(customers[1].payments.length === 0);
+            assert.equal(customers[0].payments.length, 1);
+            assert.equal(customers[0].payments[0].amount, 1);
+            assert.equal(customers[1].payments.length, 0);
             done();
           });
         });

--- a/interfaces/associations/hasMany/findOne.populate.js
+++ b/interfaces/associations/hasMany/findOne.populate.js
@@ -43,7 +43,7 @@ describe('Association Interface', function() {
           assert(!err);
 
           assert(Array.isArray(customer.payments));
-          assert(customer.payments.length === 4);
+          assert.equal(customer.payments.length, 4);
           done();
         });
       });
@@ -69,7 +69,7 @@ describe('Association Interface', function() {
           var obj = customer.toJSON();
 
           assert(Array.isArray(obj.payments));
-          assert(obj.payments.length === 4);
+          assert.equal(obj.payments.length, 4);
           assert(!obj.payments[0].hasOwnProperty('type'));
           assert(!obj.payments[1].hasOwnProperty('type'));
           assert(!obj.payments[2].hasOwnProperty('type'));

--- a/interfaces/associations/hasMany/multipleForeignKeys.js
+++ b/interfaces/associations/hasMany/multipleForeignKeys.js
@@ -40,11 +40,11 @@ describe('Association Interface', function() {
             .exec(function(err, customer) {
               assert(!err);
 
-              assert(customer.payments.length === 2);
-              assert(customer.payments[1].amount === 1337);
+              assert.equal(customer.payments.length, 2);
+              assert.equal(customer.payments[1].amount, 1337);
 
-              assert(customer.transactions.length === 1, 'Expected customer to have 1 transaction, but actually it has '+customer.transactions.length+', see?  \n'+require('util').inspect(customer,false,null));
-              assert(customer.transactions[0].amount === 100);
+              assert.equal(customer.transactions.length, 1, 'Expected customer to have 1 transaction, but actually it has '+customer.transactions.length+', see?  \n'+require('util').inspect(customer,false,null));
+              assert.equal(customer.transactions[0].amount, 100);
               done();
             });
           });
@@ -94,8 +94,8 @@ describe('Association Interface', function() {
             .exec(function(err, data) {
               assert(!err);
 
-              assert(data.payments.length === 1);
-              assert(data.payments[0].amount === 1);
+              assert.equal(data.payments.length, 1);
+              assert.equal(data.payments[0].amount, 1);
               done();
             });
           });

--- a/interfaces/associations/hasMany/remove.js
+++ b/interfaces/associations/hasMany/remove.js
@@ -46,7 +46,7 @@ describe('Association Interface', function() {
             .exec(function(err, data) {
               assert(!err);
 
-              assert(data.payments.length === 0);
+              assert.equal(data.payments.length, 0);
               done();
             });
           });
@@ -78,8 +78,8 @@ describe('Association Interface', function() {
           customerRecord.save(function(err) {
             assert(err);
             assert(Array.isArray(err));
-            assert(err.length === 1);
-            assert(err[0].type === 'remove');
+            assert.equal(err.length, 1);
+            assert.equal(err[0].type, 'remove');
 
             done();
           });

--- a/interfaces/associations/hasMany/update.nested.js
+++ b/interfaces/associations/hasMany/update.nested.js
@@ -51,9 +51,9 @@ describe('Association Interface', function() {
               .populate('payments')
               .exec(function(err, model) {
                 assert(!err);
-                assert(model.name === '1:m update nested - updated');
-                assert(model.payments.length === 1);
-                assert(model.payments[0].amount === 1);
+                assert.equal(model.name, '1:m update nested - updated');
+                assert.equal(model.payments.length, 1);
+                assert.equal(model.payments[0].amount, 1);
                 done();
               });
 
@@ -112,11 +112,11 @@ describe('Association Interface', function() {
               .populate('payments', { sort: 'amount ASC' })
               .exec(function(err, model) {
                 assert(!err);
-                assert(model.name === '1:m update nested - updated');
-                assert(model.payments.length === 3);
-                assert(model.payments[0].amount === 3);
-                assert(model.payments[1].amount === 4);
-                assert(model.payments[2].amount === 5);
+                assert.equal(model.name, '1:m update nested - updated');
+                assert.equal(model.payments.length, 3);
+                assert.equal(model.payments[0].amount, 3);
+                assert.equal(model.payments[1].amount, 4);
+                assert.equal(model.payments[2].amount, 5);
                 done();
               });
 
@@ -179,12 +179,12 @@ describe('Association Interface', function() {
               .populate('payments',{sort:{amount : 1}})
               .exec(function(err, model) {
                 assert(!err);
-                assert(model.name === '1:m update nested - updated');
-                assert(model.payments.length === 2);
+                assert.equal(model.name, '1:m update nested - updated');
+                assert.equal(model.payments.length, 2);
 
                 // Ensure association values were updated
-                assert(model.payments[0].amount === 1);
-                assert(model.payments[1].amount === 2);
+                assert.equal(model.payments[0].amount, 1);
+                assert.equal(model.payments[1].amount, 2);
 
                 done();
               });

--- a/interfaces/associations/hasManyThrough/find.populate.js
+++ b/interfaces/associations/hasManyThrough/find.populate.js
@@ -41,9 +41,9 @@ describe('Association Interface', function() {
           assert(!err, err);
 
           assert(Array.isArray(stadiums));
-          assert(stadiums.length === 1);
+          assert.equal(stadiums.length, 1);
           assert(Array.isArray(stadiums[0].teams));
-          assert(stadiums[0].teams.length === 1);
+          assert.equal(stadiums[0].teams.length, 1);
 
           done();
         });
@@ -70,7 +70,7 @@ describe('Association Interface', function() {
           var obj = stadiums[0].toJSON();
 
           assert(Array.isArray(obj.teams));
-          assert(obj.teams.length === 1);
+          assert.equal(obj.teams.length, 1);
           assert(!obj.teams[0].mascot);
 
           done();

--- a/interfaces/associations/manyToMany/add.js
+++ b/interfaces/associations/manyToMany/add.js
@@ -38,8 +38,8 @@ describe('Association Interface', function() {
           .exec(function(err, driver) {
             assert(!err);
 
-            assert(driver.taxis.length === 1, 'Expected driver to have one taxi, but actually there are '+driver.taxis.length+', see? `driver.taxi` =>'+require('util').inspect(driver.taxis,false,null));
-            assert(driver.taxis[0].medallion === 1);
+            assert.equal(driver.taxis.length, 1, 'Expected driver to have one taxi, but actually there are '+driver.taxis.length+', see? `driver.taxi` =>'+require('util').inspect(driver.taxis,false,null));
+            assert.equal(driver.taxis[0].medallion, 1);
 
             done();
           });
@@ -87,8 +87,8 @@ describe('Association Interface', function() {
           .exec(function(err, data) {
             assert(!err);
 
-            assert(data.taxis.length === 1);
-            assert(data.taxis[0].medallion === 20);
+            assert.equal(data.taxis.length, 1);
+            assert.equal(data.taxis[0].medallion, 20);
             done();
           });
         });
@@ -108,8 +108,8 @@ describe('Association Interface', function() {
             .exec(function(err, data) {
               assert(!err);
   
-              assert(data.taxis.length === 1);
-              assert(data.taxis[0].medallion === 30);
+              assert.equal(data.taxis.length, 1);
+              assert.equal(data.taxis[0].medallion, 30);
               done();
             });
           });
@@ -121,7 +121,7 @@ describe('Association Interface', function() {
         driverRecord.save(function(err) {
           assert(err);
           assert(Array.isArray(err));
-          assert(err.length === 1);
+          assert.equal(err.length, 1);
           done();
         });
       });

--- a/interfaces/associations/manyToMany/create.nested.js
+++ b/interfaces/associations/manyToMany/create.nested.js
@@ -32,8 +32,8 @@ describe('Association Interface', function() {
               .populate('taxis',{sort : {medallion : 1}})
               .exec(function(err, model) {
                 assert(!err);
-                assert(model.taxis.length === 2);
-                assert(model.taxis[1].medallion === 2);
+                assert.equal(model.taxis.length, 2);
+                assert.equal(model.taxis[1].medallion, 2);
                 done();
               });
 
@@ -74,8 +74,8 @@ describe('Association Interface', function() {
               .populate('taxis')
               .exec(function(err, model) {
                 assert(!err);
-                assert(model.taxis.length === 2);
-                assert(model.taxis[1].medallion === 2);
+                assert.equal(model.taxis.length, 2);
+                assert.equal(model.taxis[1].medallion, 2);
                 done();
               });
 

--- a/interfaces/associations/manyToMany/destroy.js
+++ b/interfaces/associations/manyToMany/destroy.js
@@ -44,7 +44,7 @@ describe('Association Interface', function() {
         Associations.Driver_taxis__taxi_drivers.find({ driver_taxis: parentId })
         .exec(function(err, records) {
           assert(!err);
-          assert(records.length === 0);
+          assert.equal(records.length, 0);
           done();
         });
       });

--- a/interfaces/associations/manyToMany/find.populate.js
+++ b/interfaces/associations/manyToMany/find.populate.js
@@ -40,9 +40,9 @@ describe('Association Interface', function() {
         assert(!err);
 
         assert(Array.isArray(drivers));
-        assert(drivers.length === 1);
+        assert.equal(drivers.length, 1);
         assert(Array.isArray(drivers[0].taxis));
-        assert(drivers[0].taxis.length === 2);
+        assert.equal(drivers[0].taxis.length, 2);
 
         done();
       });
@@ -70,7 +70,7 @@ describe('Association Interface', function() {
         assert(!obj.name);
 
         assert(Array.isArray(obj.taxis));
-        assert(obj.taxis.length === 2);
+        assert.equal(obj.taxis.length, 2);
 
         assert(obj.taxis[0].hasOwnProperty('createdAt'));
         assert(!obj.taxis[0].hasOwnProperty('medallion'));

--- a/interfaces/associations/manyToMany/find.populate.where.js
+++ b/interfaces/associations/manyToMany/find.populate.where.js
@@ -40,9 +40,9 @@ describe('Association Interface', function() {
         assert(!err, err);
 
         assert(Array.isArray(drivers));
-        assert(drivers.length === 1);
+        assert.equal(drivers.length, 1);
         assert(Array.isArray(drivers[0].taxis));
-        assert(drivers[0].taxis.length === 2, 'Expected first driver to have 2 taxis, but got '+drivers[0].taxis.length+', see?\n'+require('util').inspect(drivers[0]) );
+        assert.equal(drivers[0].taxis.length, 2, 'Expected first driver to have 2 taxis, but got '+drivers[0].taxis.length+', see?\n'+require('util').inspect(drivers[0]) );
 
         done();
       });
@@ -55,13 +55,13 @@ describe('Association Interface', function() {
         assert(!err);
 
         assert(Array.isArray(drivers));
-        assert(drivers.length === 1);
+        assert.equal(drivers.length, 1);
 
         assert(Array.isArray(drivers[0].taxis));
 
-        assert(drivers[0].taxis.length === 2, 'Expected first driver to have 2 taxis, but got '+drivers[0].taxis.length+', see?\n'+require('util').inspect(drivers[0]));
-        assert(drivers[0].taxis[0].medallion === 1, 'Expected first driver\'s first taxi to have medallion===1, but heres what I got for the first driver: '+require('util').inspect(drivers[0], false, null));
-        assert(drivers[0].taxis[1].medallion === 2, 'Expected first driver\'s second taxi to have medallion===2, but heres what I got for the first driver: '+require('util').inspect(drivers[0], false, null));
+        assert.equal(drivers[0].taxis.length, 2, 'Expected first driver to have 2 taxis, but got '+drivers[0].taxis.length+', see?\n'+require('util').inspect(drivers[0]));
+        assert.equal(drivers[0].taxis[0].medallion, 1, 'Expected first driver\'s first taxi to have medallion===1, but heres what I got for the first driver: '+require('util').inspect(drivers[0], false, null));
+        assert.equal(drivers[0].taxis[1].medallion, 2, 'Expected first driver\'s second taxi to have medallion===2, but heres what I got for the first driver: '+require('util').inspect(drivers[0], false, null));
 
         done();
       });

--- a/interfaces/associations/manyToMany/findOne.populate.js
+++ b/interfaces/associations/manyToMany/findOne.populate.js
@@ -39,7 +39,7 @@ describe('Association Interface', function() {
         assert(!err);
 
         assert(Array.isArray(driver.taxis));
-        assert(driver.taxis.length === 2);
+        assert.equal(driver.taxis.length, 2);
 
         done();
       });
@@ -67,7 +67,7 @@ describe('Association Interface', function() {
         assert(!obj.name);
 
         assert(Array.isArray(obj.taxis));
-        assert(obj.taxis.length === 2);
+        assert.equal(obj.taxis.length, 2);
 
         assert(obj.taxis[0].hasOwnProperty('createdAt'));
         assert(!obj.taxis[0].hasOwnProperty('medallion'));

--- a/interfaces/associations/manyToMany/remove.js
+++ b/interfaces/associations/manyToMany/remove.js
@@ -54,7 +54,7 @@ describe('Association Interface', function() {
           .exec(function(err, data) {
             assert(!err);
 
-            assert(data.taxis.length === 1);
+            assert.equal(data.taxis.length, 1);
             done();
           });
         });
@@ -87,8 +87,8 @@ describe('Association Interface', function() {
         driverRecord.save(function(err) {
           assert(err);
           assert(Array.isArray(err));
-          assert(err.length === 1);
-          assert(err[0].type === 'remove');
+          assert.equal(err.length, 1);
+          assert.equal(err[0].type, 'remove');
 
           done();
         });

--- a/interfaces/associations/manyToMany/update.nested.js
+++ b/interfaces/associations/manyToMany/update.nested.js
@@ -49,9 +49,9 @@ describe('Association Interface', function() {
               .populate('taxis')
               .exec(function(err, model) {
                 assert(!err);
-                assert(model.name === 'm:m update nested - updated');
-                assert(model.taxis.length === 1);
-                assert(model.taxis[0].medallion === 1);
+                assert.equal(model.name, 'm:m update nested - updated');
+                assert.equal(model.taxis.length, 1);
+                assert.equal(model.taxis[0].medallion, 1);
                 done();
               });
 
@@ -110,11 +110,11 @@ describe('Association Interface', function() {
               .populate('taxis',{sort : {medallion : 1}})
               .exec(function(err, model) {
                 assert(!err, 'Error: ' + err);
-                assert(model.name === 'm:m update nested - updated');
-                assert(model.taxis.length === 3);
-                assert(model.taxis[0].medallion === 3);
-                assert(model.taxis[1].medallion === 4);
-                assert(model.taxis[2].medallion === 5);
+                assert.equal(model.name, 'm:m update nested - updated');
+                assert.equal(model.taxis.length, 3);
+                assert.equal(model.taxis[0].medallion, 3);
+                assert.equal(model.taxis[1].medallion, 4);
+                assert.equal(model.taxis[2].medallion, 5);
                 done();
               });
 
@@ -177,12 +177,12 @@ describe('Association Interface', function() {
               .populate('taxis',{sort : {medallion : 1}})
               .exec(function(err, model) {
                 assert(!err);
-                assert(model.name === 'm:m update nested - updated');
-                assert(model.taxis.length === 2);
+                assert.equal(model.name, 'm:m update nested - updated');
+                assert.equal(model.taxis.length, 2);
 
                 // Ensure association values were updated
-                assert(model.taxis[0].medallion === 1);
-                assert(model.taxis[1].medallion === 2);
+                assert.equal(model.taxis[0].medallion, 1);
+                assert.equal(model.taxis[1].medallion, 2);
 
                 done();
               });
@@ -235,8 +235,8 @@ describe('Association Interface', function() {
                 .populate('taxis')
                 .exec(function(err, model) {
                   assert(!err);
-                  assert(model.taxis.length === 1);
-                  assert(model.taxis[0].medallion === 1001);
+                  assert.equal(model.taxis.length, 1);
+                  assert.equal(model.taxis[0].medallion, 1001);
                   done();
                 });
               });

--- a/interfaces/associations/oneToOne/find.populate.js
+++ b/interfaces/associations/oneToOne/find.populate.js
@@ -60,8 +60,8 @@ describe('Association Interface', function() {
           assert(profiles[0].user);
           assert(profiles[1].user);
 
-          assert(profiles[0].user.name === 'foo1');
-          assert(profiles[1].user.name === 'bar1');
+          assert.equal(profiles[0].user.name, 'foo1');
+          assert.equal(profiles[1].user.name, 'bar1');
 
           done();
         });
@@ -77,8 +77,8 @@ describe('Association Interface', function() {
           assert(users[0].profile);
           assert(users[1].profile);
 
-          assert(users[0].profile.name === 'profile one');
-          assert(users[1].profile.name === 'profile two');
+          assert.equal(users[0].profile.name, 'profile one');
+          assert.equal(users[1].profile.name, 'profile two');
 
           done();
         });

--- a/interfaces/migratable/migrate.alter.test.js
+++ b/interfaces/migratable/migrate.alter.test.js
@@ -18,7 +18,7 @@ describe('Migratable Interface', function() {
   function runTests(collectionName) {
 
       it('should have the proper migrate setting when bootstrapping', function() {
-        assert(Migratable[collectionName].migrate === 'alter');
+        assert.equal(Migratable[collectionName].migrate, 'alter');
       });
 
       it('should have tables', function(done) {
@@ -43,7 +43,7 @@ describe('Migratable Interface', function() {
               var ontology = obj.ontology;
               ontology.collections[collectionName.toLowerCase()].count().exec(function(err, numOfPirates) {
                 assert(!err);
-                assert(numOfPirates === 1, numOfPirates);
+                assert.equal(numOfPirates, 1);
                 done();
               });
             });

--- a/interfaces/migratable/migrate.drop.test.js
+++ b/interfaces/migratable/migrate.drop.test.js
@@ -10,7 +10,7 @@ describe('Migratable Interface', function() {
   describe('migrate: "drop"', function() {
 
     it('should have the proper migrate setting when bootstrapping', function() {
-      assert(Migratable.Drop.migrate === 'drop');
+      assert.equal(Migratable.Drop.migrate, 'drop');
     });
 
     it('should have tables', function(done) {
@@ -35,7 +35,7 @@ describe('Migratable Interface', function() {
 
             ontology.collections.drop.count().exec(function(err, numOfPirates) {
               assert(!err);
-              assert(numOfPirates === 0);
+              assert.equal(numOfPirates, 0);
               done();
             });
           });

--- a/interfaces/migratable/migrate.safe.test.js
+++ b/interfaces/migratable/migrate.safe.test.js
@@ -10,7 +10,7 @@ describe('Migratable Interface', function() {
   describe('migrate: "safe"', function() {
 
     it('should have the proper migrate setting when bootstrapping', function() {
-      assert(Migratable.Safe.migrate === 'safe');
+      assert.equal(Migratable.Safe.migrate, 'safe');
     });
 
     it('should have NOT have tables', function(done) {

--- a/interfaces/migratable/schema.test.js
+++ b/interfaces/migratable/schema.test.js
@@ -19,7 +19,7 @@ describe('Migratable Interface', function() {
 
       it('should set attribute as primary key', function(done) {
         Migratable.Document.describe(function (err, user) {
-          assert(user.title.primaryKey === true);
+          assert.equal(user.title.primaryKey, true);
           done();
         });
       });
@@ -47,7 +47,7 @@ describe('Migratable Interface', function() {
       //       return done();
       //     }
 
-      //     assert(user.number.autoIncrement === true);
+      //     assert.equal(user.number.autoIncrement, true);
       //     done();
       //   });
       // });
@@ -64,9 +64,9 @@ describe('Migratable Interface', function() {
       //     }
 
       //     Document.create({ title: 'autoincrement 1' }, function(err, record) {
-      //       assert(record.number === 1);
+      //       assert.equal(record.number, 1);
       //       Document.create({ title: 'autoincrement 2' }, function(err, record) {
-      //         assert(record.number === 2);
+      //         assert.equal(record.number, 2);
       //         done();
       //       });
       //     });
@@ -75,7 +75,7 @@ describe('Migratable Interface', function() {
 
       it('should not allow multiple records with the same PK', function(done) {
         Migratable.Document.create({ title: '100' }, function(err, record) {
-          assert(record.title === '100');
+          assert.equal(record.title, '100');
           Migratable.Document.create({ title: '100' }, function(err, record) {
             assert(err);
             assert(!record);
@@ -94,7 +94,7 @@ describe('Migratable Interface', function() {
 
       it('should set unique on schema attribute', function(done) {
         Migratable.Document.describe(function (err, user) {
-          assert(user.serialNumber.unique === true);
+          assert.equal(user.serialNumber.unique, true);
           done();
         });
       });
@@ -102,7 +102,7 @@ describe('Migratable Interface', function() {
       it('should return an error if unique constraint fails', function(done) {
         Migratable.Document.create({ title: 'uniqueConstraint 1', serialNumber: 'test' }, function(err, record) {
           assert(!err);
-          assert(record.serialNumber === 'test');
+          assert.equal(record.serialNumber, 'test');
 
           Migratable.Document.create({ title: 'uniqueConstraint 2', serialNumber: 'test' }, function(err, record) {
             assert(!record);

--- a/interfaces/queryable/caseInsensitive.test.js
+++ b/interfaces/queryable/caseInsensitive.test.js
@@ -33,7 +33,7 @@ describe('Queryable Interface', function() {
       it('should work in a case insensitve fashion by default', function(done) {
         Queryable.User.findOne({where:{ first_name: 'theothertest', type: 'case sensitivity'}, sort:{age : 1}}, function(err, user) {
           assert(user.id);
-          assert(user.first_name === 'tHeOtherTest');
+          assert.equal(user.first_name, 'tHeOtherTest');
           assert(toString.call(user.createdAt) == '[object Date]');
           assert(toString.call(user.updatedAt) == '[object Date]');
           done();
@@ -43,7 +43,7 @@ describe('Queryable Interface', function() {
       it('should work with findOneBy*()', function(done) {
         Queryable.User.findOneByFirst_name('theothertest', function(err, user) {
           assert(user.id);
-          assert(user.first_name === 'tHeOtherTest');
+          assert.equal(user.first_name, 'tHeOtherTest');
           assert(toString.call(user.createdAt) == '[object Date]');
           assert(toString.call(user.updatedAt) == '[object Date]');
           done();
@@ -60,18 +60,18 @@ describe('Queryable Interface', function() {
 
       it('should work in a case insensitve fashion by default', function(done) {
         Queryable.User.find({where : { first_name: 'thetest', type: 'case sensitivity'}, sort:{age : 1}}, function(err, users) {
-          assert(users.length === 3);
+          assert.equal(users.length, 3);
           assert(users[0].id);
-          assert(users[0].first_name === 'tHeTest');
+          assert.equal(users[0].first_name, 'tHeTest');
           done();
         });
       });
 
       it('should work with findBy*()', function(done) {
         Queryable.User.findByFirst_name('thetest').sort({age : 1}).exec( function(err, users) {
-          assert(users.length === 3);
+          assert.equal(users.length, 3);
           assert(users[0].id);
-          assert(users[0].first_name === 'tHeTest');
+          assert.equal(users[0].first_name, 'tHeTest');
           done();
         });
       });
@@ -106,45 +106,45 @@ describe('Queryable Interface', function() {
 
       it('contains should work in a case insensitive fashion by default', function(done) {
         Queryable.User.find({where : { first_name: { contains: 'hete'}, type: 'case sensitivity' },sort:{age : 1}}, function(err, users) {
-          assert(users.length === 3);
+          assert.equal(users.length, 3);
           assert(users[0].id);
-          assert(users[0].first_name === 'tHeTest');
+          assert.equal(users[0].first_name, 'tHeTest');
           done();
         });
       });
 
       it('startsWith should work in a case insensitive fashion by default', function(done) {
         Queryable.User.find({where : { first_name: { startsWith: 'the'}, type: 'case sensitivity' },sort:{age : 1}}, function(err, users) {
-          assert(users.length === 4);
+          assert.equal(users.length, 4);
           assert(users[0].id);
-          assert(users[0].first_name === 'tHeTest');
+          assert.equal(users[0].first_name, 'tHeTest');
           done();
         });
       });
 
       it('endsWith should work in a case insensitive fashion by default', function(done) {
         Queryable.User.find({where : { first_name: { endsWith: 'est'}, type: 'case sensitivity' },sort:{age : 1}}, function(err, users) {
-          assert(users.length === 5);
+          assert.equal(users.length, 5);
           assert(users[0].id);
-          assert(users[0].first_name === 'tHeTest');
+          assert.equal(users[0].first_name, 'tHeTest');
           done();
         });
       });
 
       it('like should work in a case insensitive fashion by default', function(done) {
         Queryable.User.find({where : { first_name: { like: '%hete%'}, type: 'case sensitivity' },sort:{age : 1}}, function(err, users) {
-          assert(users.length === 3);
+          assert.equal(users.length, 3);
           assert(users[0].id);
-          assert(users[0].first_name === 'tHeTest');
+          assert.equal(users[0].first_name, 'tHeTest');
           done();
         });
       });
 
       it('endsWith should actually enforce endswith', function(done) {
         Queryable.User.find({where : { first_name: { endsWith: 'AR)H$daxx'}, type: 'case sensitivity' },sort:{age : 1}}, function(err, users) {
-          assert(users.length === 1);
+          assert.equal(users.length, 1);
           assert(users[0].id);
-          assert(users[0].first_name === 'AR)H$daxx');
+          assert.equal(users[0].first_name, 'AR)H$daxx');
           done();
         });
       });
@@ -175,18 +175,18 @@ describe('Queryable Interface', function() {
 
       it('should escape stars', function(done) {
         Queryable.User.find({ first_name: '****Awesome****', type: 'case sensitivity' }, function(err, users) {
-          assert(users.length === 1);
+          assert.equal(users.length, 1);
           assert(users[0].id);
-          assert(users[0].first_name === '****Awesome****');
+          assert.equal(users[0].first_name, '****Awesome****');
           done();
         });
       });
 
       it('contains should work with stars in the name', function(done) {
         Queryable.User.find({ first_name: { contains: '**Awesome**'}, type: 'case sensitivity' }, function(err, users) {
-          assert(users.length === 1);
+          assert.equal(users.length, 1);
           assert(users[0].id);
-          assert(users[0].first_name === '****Awesome****');
+          assert.equal(users[0].first_name, '****Awesome****');
           done();
         });
       });

--- a/interfaces/queryable/count.test.js
+++ b/interfaces/queryable/count.test.js
@@ -34,7 +34,7 @@ describe('Queryable Interface', function() {
     it('should accurately count records', function(done) {
       Queryable.User.count({ type: 'count' }, function(err, count) {
         assert(!err);
-        assert(count === 10);
+        assert.equal(count, 10);
         done();
       });
     });
@@ -42,7 +42,7 @@ describe('Queryable Interface', function() {
     it('should work with dynamic finders', function(done) {
       Queryable.User.countByType('count', function(err, count) {
         assert(!err);
-        assert(count === 10);
+        assert.equal(count, 10);
         done();
       });
     });

--- a/interfaces/queryable/findLike.test.js
+++ b/interfaces/queryable/findLike.test.js
@@ -22,7 +22,7 @@ describe('Queryable Interface', function() {
         Queryable.User.findLike({ first_name: part }, function(err, users) {
           assert(!err);
           assert(Array.isArray(users));
-          assert(users.length === 2, util.format('expected 2 users, but got %s, see?\n%s', users.length, util.inspect(users, false, null) ));
+          assert.equal(users.length, 2, util.format('expected 2 users, but got %s, see?\n%s', users.length, util.inspect(users, false, null) ));
           assert((users[0].first_name === testName && users[1].first_name === testName2) ||
                  (users[0].first_name === testName2 && users[1].first_name === testName))
           done();

--- a/interfaces/queryable/findOneLike.test.js
+++ b/interfaces/queryable/findOneLike.test.js
@@ -18,7 +18,7 @@ describe('Queryable Interface', function() {
 
         Queryable.User.findOneLike({ first_name: part }, function(err, user) {
           assert(!err);
-          assert(user.first_name === testName);
+          assert.equal(user.first_name, testName);
           done();
         });
       });

--- a/interfaces/queryable/modifiers/average.modifier.test.js
+++ b/interfaces/queryable/modifiers/average.modifier.test.js
@@ -37,7 +37,7 @@ describe('Queryable Interface', function() {
     it('should average by key and only return that key with the average value', function(done) {
       Queryable.User.find({ where:{type: 'average test'}, average: ['age'] }, function(err, averages) {
         assert(!err,err);
-        assert(averages[0].age === 4.5, 'expected averages[0].age to === 4.5, instead averages ==='+require('util').inspect(averages, false, null));
+        assert.equal(averages[0].age, 4.5, 'expected averages[0].age to === 4.5, instead averages ==='+require('util').inspect(averages, false, null));
         done();
       });
     });
@@ -45,8 +45,8 @@ describe('Queryable Interface', function() {
     it('should average by multiple keys and return averages per key', function(done) {
       Queryable.User.find({ where:{type: 'average test'}, average: ['age', 'percent'] }, function(err, averages) {
         assert(!err,err);
-        assert(averages[0].age === 4.5, 'expected averages[0].age to === 4.5, instead averages[0] ==='+require('util').inspect(averages[0], false, null));
-        assert(averages[0].percent === 2.25);
+        assert.equal(averages[0].age, 4.5, 'expected averages[0].age to === 4.5, instead averages[0] ==='+require('util').inspect(averages[0], false, null));
+        assert.equal(averages[0].percent, 2.25);
         done();
       });
     });

--- a/interfaces/queryable/modifiers/contains.modifier.test.js
+++ b/interfaces/queryable/modifiers/contains.modifier.test.js
@@ -21,8 +21,8 @@ describe('Queryable Interface', function() {
             Queryable.User.contains({ first_name: part }, function(err, users) {
               assert(!err);
               assert(Array.isArray(users));
-              assert(users.length === 1);
-              assert(users[0].first_name === testName);
+              assert.equal(users.length, 1);
+              assert.equal(users[0].first_name, testName);
               done();
             });
           });
@@ -45,8 +45,8 @@ describe('Queryable Interface', function() {
             Queryable.User.where({ first_name: { contains: part }}, function(err, users) {
               assert(!err);
               assert(Array.isArray(users));
-              assert(users.length === 1);
-              assert(users[0].first_name === testName);
+              assert.equal(users.length, 1);
+              assert.equal(users[0].first_name, testName);
               done();
             });
           });
@@ -69,8 +69,8 @@ describe('Queryable Interface', function() {
             Queryable.User.typeContains(part, function(err, users) {
               assert(!err);
               assert(Array.isArray(users));
-              assert(users.length === 1);
-              assert(users[0].type === testType);
+              assert.equal(users.length, 1);
+              assert.equal(users[0].type, testType);
               done();
             });
           });

--- a/interfaces/queryable/modifiers/endsWith.modifier.test.js
+++ b/interfaces/queryable/modifiers/endsWith.modifier.test.js
@@ -21,8 +21,8 @@ describe('Queryable Interface', function() {
             Queryable.User.endsWith({ first_name: part }, function(err, users) {
               assert(!err);
               assert(Array.isArray(users));
-              assert(users.length === 1);
-              assert(users[0].first_name === testName);
+              assert.equal(users.length, 1);
+              assert.equal(users[0].first_name, testName);
               done();
             });
           });
@@ -45,8 +45,8 @@ describe('Queryable Interface', function() {
             Queryable.User.where({ first_name: { endsWith: part }}, function(err, users) {
               assert(!err);
               assert(Array.isArray(users));
-              assert(users.length === 1);
-              assert(users[0].first_name === testName);
+              assert.equal(users.length, 1);
+              assert.equal(users[0].first_name, testName);
               done();
             });
           });
@@ -69,8 +69,8 @@ describe('Queryable Interface', function() {
             Queryable.User.typeEndsWith(part, function(err, users) {
               assert(!err);
               assert(Array.isArray(users));
-              assert(users.length === 1);
-              assert(users[0].type === testType);
+              assert.equal(users.length, 1);
+              assert.equal(users[0].type, testType);
               done();
             });
           });

--- a/interfaces/queryable/modifiers/greaterThan.modifier.test.js
+++ b/interfaces/queryable/modifiers/greaterThan.modifier.test.js
@@ -34,8 +34,8 @@ describe('Queryable Interface', function() {
           Queryable.User.find({ first_name: testName, age: { greaterThan: 40 }}).sort('age').exec(function(err, users) {
             assert(!err);
             assert(Array.isArray(users));
-            assert(users.length === 3);
-            assert(users[0].age === 41);
+            assert.equal(users.length, 3);
+            assert.equal(users[0].age, 41);
             done();
           });
         });
@@ -44,8 +44,8 @@ describe('Queryable Interface', function() {
           Queryable.User.find({ first_name: testName, age: { '>': 40 }}).sort('age').exec(function(err, users) {
             assert(!err);
             assert(Array.isArray(users));
-            assert(users.length === 3);
-            assert(users[0].age === 41);
+            assert.equal(users.length, 3);
+            assert.equal(users[0].age, 41);
             done();
           });
         });
@@ -89,8 +89,8 @@ describe('Queryable Interface', function() {
           Queryable.User.find({ type: testName, dob: { greaterThan: new Date(2013, 10, 9) }}).sort('first_name').exec(function(err, users) {
             assert(!err);
             assert(Array.isArray(users));
-            assert(users.length === 1);
-            assert(users[0].first_name === 'greaterThan_dates_user9');
+            assert.equal(users.length, 1);
+            assert.equal(users[0].first_name, 'greaterThan_dates_user9');
             done();
           });
         });
@@ -99,8 +99,8 @@ describe('Queryable Interface', function() {
           Queryable.User.find({ type: testName, dob: { '>': new Date(2013, 10, 9) }}).sort('first_name').exec(function(err, users) {
             assert(!err);
             assert(Array.isArray(users));
-            assert(users.length === 1);
-            assert(users[0].first_name === 'greaterThan_dates_user9');
+            assert.equal(users.length, 1);
+            assert.equal(users[0].first_name, 'greaterThan_dates_user9');
             done();
           });
         });
@@ -142,8 +142,8 @@ describe('Queryable Interface', function() {
           Queryable.User.find({ type: testName, first_name: { greaterThan: '2 greaterThan_strings_user' }}).sort('first_name').exec(function(err, users) {
             assert(!err);
             assert(Array.isArray(users));
-            assert(users.length === 7);
-            assert(users[0].first_name === '3 greaterThan_strings_user');
+            assert.equal(users.length, 7);
+            assert.equal(users[0].first_name, '3 greaterThan_strings_user');
             done();
           });
         });
@@ -152,8 +152,8 @@ describe('Queryable Interface', function() {
           Queryable.User.find({ type: testName, first_name: { '>': '2 greaterThan_strings_user' }}).sort('first_name').exec(function(err, users) {
             assert(!err);
             assert(Array.isArray(users));
-            assert(users.length === 7);
-            assert(users[0].first_name === '3 greaterThan_strings_user');
+            assert.equal(users.length, 7);
+            assert.equal(users[0].first_name, '3 greaterThan_strings_user');
             done();
           });
         });
@@ -192,8 +192,8 @@ describe('Queryable Interface', function() {
           Queryable.User.find({ first_name: testName, age: { greaterThanOrEqual: 41 }}).sort('age').exec(function(err, users) {
             assert(!err);
             assert(Array.isArray(users));
-            assert(users.length === 3);
-            assert(users[0].age === 41);
+            assert.equal(users.length, 3);
+            assert.equal(users[0].age, 41);
             done();
           });
         });
@@ -202,8 +202,8 @@ describe('Queryable Interface', function() {
           Queryable.User.find({ first_name: testName, age: { '>=': 41 }}).sort('age').exec(function(err, users) {
             assert(!err);
             assert(Array.isArray(users));
-            assert(users.length === 3);
-            assert(users[0].age === 41);
+            assert.equal(users.length, 3);
+            assert.equal(users[0].age, 41);
             done();
           });
         });
@@ -247,8 +247,8 @@ describe('Queryable Interface', function() {
           Queryable.User.find({ type: testName, dob: { greaterThanOrEqual: new Date(2013, 10, 9) }}).sort('first_name').exec(function(err, users) {
             assert(!err);
             assert(Array.isArray(users));
-            assert(users.length === 2);
-            assert(users[0].first_name === 'greaterThanOrEqual_dates_user8');
+            assert.equal(users.length, 2);
+            assert.equal(users[0].first_name, 'greaterThanOrEqual_dates_user8');
             done();
           });
         });
@@ -257,8 +257,8 @@ describe('Queryable Interface', function() {
           Queryable.User.find({ type: testName, dob: { '>=': new Date(2013, 10, 9) }}).sort('first_name').exec(function(err, users) {
             assert(!err);
             assert(Array.isArray(users));
-            assert(users.length === 2);
-            assert(users[0].first_name === 'greaterThanOrEqual_dates_user8');
+            assert.equal(users.length, 2);
+            assert.equal(users[0].first_name, 'greaterThanOrEqual_dates_user8');
             done();
           });
         });
@@ -300,8 +300,8 @@ describe('Queryable Interface', function() {
           Queryable.User.find({ type: testName, first_name: { greaterThanOrEqual: '2 greaterThanOrEqual_strings_user' }}).sort('first_name').exec(function(err, users) {
             assert(!err);
             assert(Array.isArray(users));
-            assert(users.length === 8);
-            assert(users[0].first_name === '2 greaterThanOrEqual_strings_user');
+            assert.equal(users.length, 8);
+            assert.equal(users[0].first_name, '2 greaterThanOrEqual_strings_user');
             done();
           });
         });
@@ -310,8 +310,8 @@ describe('Queryable Interface', function() {
           Queryable.User.find({ type: testName, first_name: { '>=': '2 greaterThanOrEqual_strings_user' }}).sort('first_name').exec(function(err, users) {
             assert(!err);
             assert(Array.isArray(users));
-            assert(users.length === 8);
-            assert(users[0].first_name === '2 greaterThanOrEqual_strings_user');
+            assert.equal(users.length, 8);
+            assert.equal(users[0].first_name, '2 greaterThanOrEqual_strings_user');
             done();
           });
         });

--- a/interfaces/queryable/modifiers/groupBy.modifier.test.js
+++ b/interfaces/queryable/modifiers/groupBy.modifier.test.js
@@ -41,7 +41,7 @@ describe('Queryable Interface', function() {
 
         asserted = grouped.filter(function(result){
           if(result.type === 'groupBy test') {
-            assert(result.age === 45); // 45 === 0+1+2+3+4+5+6+7+8+9
+            assert.equal(result.age, 45); // 45 === 0+1+2+3+4+5+6+7+8+9
             return true;
           }
           return false;
@@ -61,7 +61,7 @@ describe('Queryable Interface', function() {
 
         var asserted = grouped.filter(function(result){
           if(result.type === 'groupBy test' && result.age === 1) {
-            assert(result.percent === 0.5);
+            assert.equal(result.percent, 0.5);
             return true;
           }
         });
@@ -79,8 +79,8 @@ describe('Queryable Interface', function() {
         assert(!err);
         var asserted = grouped.filter(function(result){
           if(result.type === 'groupBy test') {
-            assert(result.age === 45);
-            assert(result.percent === 2.25);
+            assert.equal(result.age, 45);
+            assert.equal(result.percent, 2.25);
             return true;
           }
         });
@@ -98,8 +98,8 @@ describe('Queryable Interface', function() {
         assert(!err);
         var asserted = grouped.filter(function(result){
           if(result.type === 'groupBy test') {
-            assert(result.age === 30);
-            assert(result.percent === 3.75);
+            assert.equal(result.age, 30);
+            assert.equal(result.percent, 3.75);
             return true;
           }
         });

--- a/interfaces/queryable/modifiers/in.modifier.test.js
+++ b/interfaces/queryable/modifiers/in.modifier.test.js
@@ -32,7 +32,7 @@ describe('Queryable Interface', function() {
 
           Queryable.User.find({ first_name: [] }, function(err, users) {
             assert(users);
-            assert(users.length === 0);
+            assert.equal(users.length, 0);
             done();
           });
         });
@@ -41,8 +41,8 @@ describe('Queryable Interface', function() {
       it('should return correct user', function(done) {
         Queryable.User.find({ first_name: ["foo", testName, "bar", "baz"] }, function(err, users) {
           assert(!err);
-          assert(users.length === 1);
-          assert(users[0].first_name === testName);
+          assert.equal(users.length, 1);
+          assert.equal(users[0].first_name, testName);
           done();
         });
       });
@@ -50,7 +50,7 @@ describe('Queryable Interface', function() {
       it('should return a model instance', function(done) {
         Queryable.User.find({ first_name: ["foo", testName, "bar", "baz"] }, function(err, users) {
           assert(users[0].id);
-          assert(typeof users[0].fullName === 'function');
+          assert.equal(typeof users[0].fullName, 'function');
           assert(toString.call(users[0].createdAt) == '[object Date]');
           assert(toString.call(users[0].updatedAt) == '[object Date]');
           done();
@@ -66,7 +66,7 @@ describe('Queryable Interface', function() {
 
       it('should return an empty array', function(done) {
         Queryable.User.find({ first_name: ["foo", "bar", "baz"] }, function(err, users) {
-          assert(users.length === 0);
+          assert.equal(users.length, 0);
           done();
         });
       });

--- a/interfaces/queryable/modifiers/lessThan.modifier.test.js
+++ b/interfaces/queryable/modifiers/lessThan.modifier.test.js
@@ -38,8 +38,8 @@ describe('Queryable Interface', function() {
           .exec(function(err, users) {
             assert(!err);
             assert(Array.isArray(users));
-            assert(users.length === 2);
-            assert(users[0].age === 40);
+            assert.equal(users.length, 2);
+            assert.equal(users[0].age, 40);
             done();
           });
         });
@@ -50,8 +50,8 @@ describe('Queryable Interface', function() {
           .exec(function(err, users) {
             assert(!err);
             assert(Array.isArray(users));
-            assert(users.length === 2);
-            assert(users[0].age === 40);
+            assert.equal(users.length, 2);
+            assert.equal(users[0].age, 40);
             done();
           });
         });
@@ -95,8 +95,8 @@ describe('Queryable Interface', function() {
           Queryable.User.find({ type: testName, dob: { lessThan: new Date(2013, 10, 2) }}).sort('first_name').exec(function(err, users) {
             assert(!err);
             assert(Array.isArray(users));
-            assert(users.length === 1);
-            assert(users[0].first_name === 'lessThan_dates_user0');
+            assert.equal(users.length, 1);
+            assert.equal(users[0].first_name, 'lessThan_dates_user0');
             done();
           });
         });
@@ -105,8 +105,8 @@ describe('Queryable Interface', function() {
           Queryable.User.find({ type: testName, dob: { '<': new Date(2013, 10, 2) }}).sort('first_name').exec(function(err, users) {
             assert(!err);
             assert(Array.isArray(users));
-            assert(users.length === 1);
-            assert(users[0].first_name === 'lessThan_dates_user0');
+            assert.equal(users.length, 1);
+            assert.equal(users[0].first_name, 'lessThan_dates_user0');
             done();
           });
         });
@@ -145,8 +145,8 @@ describe('Queryable Interface', function() {
           Queryable.User.find({ first_name: testName, age: { lessThanOrEqual: 42 }}).sort('age').exec(function(err, users) {
             assert(!err);
             assert(Array.isArray(users));
-            assert(users.length === 3);
-            assert(users[0].age === 40);
+            assert.equal(users.length, 3);
+            assert.equal(users[0].age, 40);
             done();
           });
         });
@@ -155,8 +155,8 @@ describe('Queryable Interface', function() {
           Queryable.User.find({ first_name: testName, age: { '<=': 42 }}).sort('age').exec(function(err, users) {
             assert(!err);
             assert(Array.isArray(users));
-            assert(users.length === 3);
-            assert(users[0].age === 40);
+            assert.equal(users.length, 3);
+            assert.equal(users[0].age, 40);
             done();
           });
         });
@@ -200,8 +200,8 @@ describe('Queryable Interface', function() {
           Queryable.User.find({ type: testName, dob: { lessThanOrEqual: new Date(2013, 10, 2) }}).sort('first_name').exec(function(err, users) {
             assert(!err);
             assert(Array.isArray(users));
-            assert(users.length === 2);
-            assert(users[1].first_name === 'lessThanOrEqual_dates_user1');
+            assert.equal(users.length, 2);
+            assert.equal(users[1].first_name, 'lessThanOrEqual_dates_user1');
             done();
           });
         });
@@ -210,8 +210,8 @@ describe('Queryable Interface', function() {
           Queryable.User.find({ type: testName, dob: { '<=': new Date(2013, 10, 2) }}).sort('first_name').exec(function(err, users) {
             assert(!err);
             assert(Array.isArray(users));
-            assert(users.length === 2);
-            assert(users[1].first_name === 'lessThanOrEqual_dates_user1');
+            assert.equal(users.length, 2);
+            assert.equal(users[1].first_name, 'lessThanOrEqual_dates_user1');
             done();
           });
         });

--- a/interfaces/queryable/modifiers/like.modifier.test.js
+++ b/interfaces/queryable/modifiers/like.modifier.test.js
@@ -21,8 +21,8 @@ describe('Queryable Interface', function() {
           Queryable.User.find({ like: { first_name: part } }, function(err, users) {
             assert(!err);
             assert(Array.isArray(users));
-            assert(users.length === 1);
-            assert(users[0].first_name === testName);
+            assert.equal(users.length, 1);
+            assert.equal(users[0].first_name, testName);
             done();
           });
         });
@@ -38,8 +38,8 @@ describe('Queryable Interface', function() {
           Queryable.User.find({ like: { first_name: '%'+part+'%' } }, function(err, users) {
             assert(!err);
             assert(Array.isArray(users));
-            assert(users.length === 1);
-            assert(users[0].first_name === testName);
+            assert.equal(users.length, 1);
+            assert.equal(users[0].first_name, testName);
             done();
           });
         });

--- a/interfaces/queryable/modifiers/limit.modifier.test.js
+++ b/interfaces/queryable/modifiers/limit.modifier.test.js
@@ -32,7 +32,7 @@ describe('Queryable Interface', function() {
       Queryable.User.find({ where: { type: 'limit test' }, limit: 3 }, function(err, users) {
         assert(!err);
         assert(Array.isArray(users));
-        assert(users.length === 3);
+        assert.equal(users.length, 3);
         done();
       });
     });
@@ -41,7 +41,7 @@ describe('Queryable Interface', function() {
       Queryable.User.findByType('limit test', { limit: 3 }, function(err, users) {
         assert(!err);
         assert(Array.isArray(users));
-        assert(users.length === 3);
+        assert.equal(users.length, 3);
         done();
       });
     });
@@ -50,7 +50,7 @@ describe('Queryable Interface', function() {
       Queryable.User.find({ where: { type: 'limit test' } }, { limit: 3 }, function(err, users) {
         assert(!err);
         assert(Array.isArray(users));
-        assert(users.length === 3);
+        assert.equal(users.length, 3);
         done();
       });
     });

--- a/interfaces/queryable/modifiers/max.modifier.test.js
+++ b/interfaces/queryable/modifiers/max.modifier.test.js
@@ -37,7 +37,7 @@ describe('Queryable Interface', function() {
     it('should get the maximum of the key', function(done) {
       Queryable.User.find({where:{type: 'max test'}, max: ['age'] }, function(err, summed) {
         assert(!err);
-        assert(summed[0].age === 9010);
+        assert.equal(summed[0].age, 9010);
         done();
       });
     });
@@ -45,8 +45,8 @@ describe('Queryable Interface', function() {
     it('should max multiple keys', function(done) {
       Queryable.User.find({where:{type: 'max test'}, max: ['age', 'percent'] }, function(err, summed) {
         assert(!err);
-        assert(summed[0].age === 9010);
-        assert(summed[0].percent === 9005.5);
+        assert.equal(summed[0].age, 9010);
+        assert.equal(summed[0].percent, 9005.5);
         done();
       });
     });
@@ -58,8 +58,8 @@ describe('Queryable Interface', function() {
         average: ['percent']
       }, function(err, summed) {
         assert(!err);
-        assert(summed[0].age === 9010);
-        assert(summed[0].percent === 9003.25);
+        assert.equal(summed[0].age, 9010);
+        assert.equal(summed[0].percent, 9003.25);
         done();
       });
     });

--- a/interfaces/queryable/modifiers/min.modifier.test.js
+++ b/interfaces/queryable/modifiers/min.modifier.test.js
@@ -37,7 +37,7 @@ describe('Queryable Interface', function() {
     it('should get the minimum of the key', function(done) {
       Queryable.User.find({ where:{type: 'min test'}, min: ['age'] }, function(err, summed) {
         assert(!err);
-        assert(summed[0].age === -9);
+        assert.equal(summed[0].age, -9);
         done();
       });
     });
@@ -45,8 +45,8 @@ describe('Queryable Interface', function() {
     it('should min multiple keys', function(done) {
       Queryable.User.find({ where:{type: 'min test'}, min: ['age', 'percent'] }, function(err, summed) {
         assert(!err);
-        assert(summed[0].age === -9);
-        assert(summed[0].percent === -4.5);
+        assert.equal(summed[0].age, -9);
+        assert.equal(summed[0].percent, -4.5);
         done();
       });
     });
@@ -58,8 +58,8 @@ describe('Queryable Interface', function() {
         average: ['percent']
       }, function(err, summed) {
         assert(!err);
-        assert(summed[0].age === -9);
-        assert(summed[0].percent === -2.25);
+        assert.equal(summed[0].age, -9);
+        assert.equal(summed[0].percent, -2.25);
         done();
       });
     });

--- a/interfaces/queryable/modifiers/not.modifier.test.js
+++ b/interfaces/queryable/modifiers/not.modifier.test.js
@@ -36,8 +36,8 @@ describe('Queryable Interface', function() {
         .exec(function(err, users) {
           assert(!err);
           assert(Array.isArray(users));
-          assert(users.length === 3);
-          assert(users[0].age === 41);
+          assert.equal(users.length, 3);
+          assert.equal(users[0].age, 41);
 
           // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
           // TODO: check that models without the attribute in question set AT ALL,
@@ -54,8 +54,8 @@ describe('Queryable Interface', function() {
         .exec(function(err, users) {
           assert(!err);
           assert(Array.isArray(users));
-          assert(users.length === 3);
-          assert(users[0].age === 41);
+          assert.equal(users.length, 3);
+          assert.equal(users[0].age, 41);
           done();
         });
       });
@@ -68,9 +68,9 @@ describe('Queryable Interface', function() {
           assert(!err);
 
           assert(Array.isArray(users));
-          assert(users.length === 3);
-          assert(users[0].age === 40);
-          assert(users[1].age === 42);
+          assert.equal(users.length, 3);
+          assert.equal(users[0].age, 40);
+          assert.equal(users[1].age, 42);
           done();
         });
       });

--- a/interfaces/queryable/modifiers/notIn.modifier.test.js
+++ b/interfaces/queryable/modifiers/notIn.modifier.test.js
@@ -34,8 +34,8 @@ describe('Queryable Interface', function() {
       it('should return correct user', function(done) {
         Queryable.User.find({ first_name: { '!': ["foo", testName, "bar", "baz"] }}, function(err, users) {
           assert(!err);
-          assert(users.length === 1);
-          assert(users[0].first_name === 'something else');
+          assert.equal(users.length, 1);
+          assert.equal(users[0].first_name, 'something else');
           done();
         });
       });
@@ -43,7 +43,7 @@ describe('Queryable Interface', function() {
       it('should return a model instance', function(done) {
         Queryable.User.find({ first_name: { '!': ["foo", testName, "bar", "baz"] }}, function(err, users) {
           assert(users[0].id);
-          assert(typeof users[0].fullName === 'function');
+          assert.equal(typeof users[0].fullName, 'function');
           assert(toString.call(users[0].createdAt) == '[object Date]');
           assert(toString.call(users[0].updatedAt) == '[object Date]');
           done();
@@ -59,7 +59,7 @@ describe('Queryable Interface', function() {
 
       it('should return an empty array', function(done) {
         Queryable.User.find({ first_name: { '!': ["foo", testName, "bar", "something else"] }}, function(err, users) {
-          assert(users.length === 0);
+          assert.equal(users.length, 0);
           done();
         });
       });

--- a/interfaces/queryable/modifiers/or.modifier.test.js
+++ b/interfaces/queryable/modifiers/or.modifier.test.js
@@ -37,9 +37,9 @@ describe('Queryable Interface', function() {
           if(err) return done(err);
 
           assert(Array.isArray(users));
-          assert(users.length === 2);
-          assert(users[0].first_name === 'OR_user0');
-          assert(users[1].first_name === 'OR_user1');
+          assert.equal(users.length, 2);
+          assert.equal(users[0].first_name, 'OR_user0');
+          assert.equal(users[1].first_name, 'OR_user1');
           done();
         });
       });
@@ -48,7 +48,7 @@ describe('Queryable Interface', function() {
         Queryable.User.find({ where: { or: [{ first_name: 'OR_user0' }, { first_name: 'OR_user1' }]}})
         .exec(function(err, users) {
           assert(users[0].id);
-          assert(typeof users[0].fullName === 'function');
+          assert.equal(typeof users[0].fullName, 'function');
           assert(toString.call(users[0].createdAt) == '[object Date]');
           assert(toString.call(users[0].updatedAt) == '[object Date]');
           done();
@@ -67,9 +67,9 @@ describe('Queryable Interface', function() {
           if(err) return done(err);
 
           assert(Array.isArray(users));
-          assert(users.length === 2);
-          assert(users[0].first_name === 'OR_user0');
-          assert(users[1].first_name === 'OR_user1');
+          assert.equal(users.length, 2);
+          assert.equal(users[0].first_name, 'OR_user0');
+          assert.equal(users[1].first_name, 'OR_user1');
           done();
         });
       });
@@ -87,9 +87,9 @@ describe('Queryable Interface', function() {
           if(err) return done(err);
 
           assert(Array.isArray(users));
-          assert(users.length === 2);
-          assert(users[0].first_name === 'OR_user1');
-          assert(users[1].first_name === 'OR_user2');
+          assert.equal(users.length, 2);
+          assert.equal(users[0].first_name, 'OR_user1');
+          assert.equal(users[1].first_name, 'OR_user2');
           done();
         });
       });
@@ -104,7 +104,7 @@ describe('Queryable Interface', function() {
       it('should return an empty array', function(done) {
         Queryable.User.find({ where: { or: [{ first_name: 'OR_user10' }, { first_name: 'OR_user11' }]}})
         .exec(function(err, users) {
-          assert(users.length === 0);
+          assert.equal(users.length, 0);
           done();
         });
       });

--- a/interfaces/queryable/modifiers/skip.modifier.test.js
+++ b/interfaces/queryable/modifiers/skip.modifier.test.js
@@ -32,7 +32,7 @@ describe('Queryable Interface', function() {
       Queryable.User.find({ where: { type: 'skip test' }, skip: 3 }, function(err, users) {
         assert(!err);
         assert(Array.isArray(users));
-        assert(users.length === 7);
+        assert.equal(users.length, 7);
         done();
       });
     });
@@ -41,7 +41,7 @@ describe('Queryable Interface', function() {
       Queryable.User.findByType('skip test', { skip: 3 }, function(err, users) {
         assert(!err);
         assert(Array.isArray(users));
-        assert(users.length === 7);
+        assert.equal(users.length, 7);
         done();
       });
     });
@@ -50,7 +50,7 @@ describe('Queryable Interface', function() {
       Queryable.User.find({ where: { type: 'skip test' } }, { skip: 3 }, function(err, users) {
         assert(!err);
         assert(Array.isArray(users));
-        assert(users.length === 7);
+        assert.equal(users.length, 7);
         done();
       });
     });

--- a/interfaces/queryable/modifiers/sort.modifier.test.js
+++ b/interfaces/queryable/modifiers/sort.modifier.test.js
@@ -39,8 +39,8 @@ describe('Queryable Interface', function() {
     it('should sort records using binary notation for asc', function(done) {
       Queryable.User.find({ where: { type: 'sort test' }, sort: { dob: 1 } }, function(err, users) {
         assert(!err);
-        assert(users.length === 10);
-        assert(users[0].first_name === 'sort_user0');
+        assert.equal(users.length, 10);
+        assert.equal(users[0].first_name, 'sort_user0');
         done();
       });
     });
@@ -48,8 +48,8 @@ describe('Queryable Interface', function() {
     it('should sort records using binary notation desc', function(done) {
       Queryable.User.find({ where: { type: 'sort test' }, sort: { dob: 0 } }, function(err, users) {
         assert(!err);
-        assert(users.length === 10);
-        assert(users[0].first_name === 'sort_user9');
+        assert.equal(users.length, 10);
+        assert.equal(users[0].first_name, 'sort_user9');
         done();
       });
     });
@@ -57,8 +57,8 @@ describe('Queryable Interface', function() {
     it('should sort records using string notation for asc', function(done) {
       Queryable.User.find({ where: { type: 'sort test' }, sort: 'dob asc' }, function(err, users) {
         assert(!err);
-        assert(users.length === 10);
-        assert(users[0].first_name === 'sort_user0');
+        assert.equal(users.length, 10);
+        assert.equal(users[0].first_name, 'sort_user0');
         done();
       });
     });
@@ -66,8 +66,8 @@ describe('Queryable Interface', function() {
     it('should sort records using string notation for desc', function(done) {
       Queryable.User.find({ where: { type: 'sort test' }, sort: 'dob desc' }, function(err, users) {
         assert(!err);
-        assert(users.length === 10);
-        assert(users[0].first_name === 'sort_user9');
+        assert.equal(users.length, 10);
+        assert.equal(users[0].first_name, 'sort_user9');
         done();
       });
     });
@@ -75,8 +75,8 @@ describe('Queryable Interface', function() {
     it('should sort when sort is an option', function(done) {
       Queryable.User.find({ where: { type: 'sort test' } }, { sort: { dob: 0 } }, function(err, users) {
         assert(!err);
-        assert(users.length === 10);
-        assert(users[0].first_name === 'sort_user9');
+        assert.equal(users.length, 10);
+        assert.equal(users[0].first_name, 'sort_user9');
         done();
       });
     });
@@ -116,12 +116,12 @@ describe('Queryable Interface', function() {
         assert(!err);
 
         // check the smith's are together and ordered by first_name
-        assert(users[0].first_name === 'bob');
-        assert(users[1].last_name === 'smith');
-        assert(users[2].last_name === 'smith');
+        assert.equal(users[0].first_name, 'bob');
+        assert.equal(users[1].last_name, 'smith');
+        assert.equal(users[2].last_name, 'smith');
 
-        assert(users[1].first_name === 'joe');
-        assert(users[2].first_name === 'foo');
+        assert.equal(users[1].first_name, 'joe');
+        assert.equal(users[2].first_name, 'foo');
         done();
       });
     });
@@ -131,12 +131,12 @@ describe('Queryable Interface', function() {
         assert(!err);
 
         // check the smith's are together and ordered by first_name
-        assert(users[0].first_name === 'bob');
-        assert(users[1].last_name === 'smith');
-        assert(users[2].last_name === 'smith');
+        assert.equal(users[0].first_name, 'bob');
+        assert.equal(users[1].last_name, 'smith');
+        assert.equal(users[2].last_name, 'smith');
 
-        assert(users[1].first_name === 'foo');
-        assert(users[2].first_name === 'joe');
+        assert.equal(users[1].first_name, 'foo');
+        assert.equal(users[2].first_name, 'joe');
         done();
       });
     });

--- a/interfaces/queryable/modifiers/startsWith.modifier.test.js
+++ b/interfaces/queryable/modifiers/startsWith.modifier.test.js
@@ -22,8 +22,8 @@ describe('Queryable Interface', function() {
             Queryable.User.startsWith({ first_name: part }, function(err, users) {
               assert(!err);
               assert(Array.isArray(users));
-              assert(users.length === 1);
-              assert(users[0].first_name === testName);
+              assert.equal(users.length, 1);
+              assert.equal(users[0].first_name, testName);
               done();
             });
           });
@@ -46,8 +46,8 @@ describe('Queryable Interface', function() {
             Queryable.User.where({ first_name: { startsWith: part }}, function(err, users) {
               assert(!err);
               assert(Array.isArray(users));
-              assert(users.length === 1);
-              assert(users[0].first_name === testName);
+              assert.equal(users.length, 1);
+              assert.equal(users[0].first_name, testName);
               done();
             });
           });
@@ -70,8 +70,8 @@ describe('Queryable Interface', function() {
             Queryable.User.typeStartsWith(part, function(err, users) {
               assert(!err);
               assert(Array.isArray(users));
-              assert(users.length === 1);
-              assert(users[0].type === testType);
+              assert.equal(users.length, 1);
+              assert.equal(users[0].type, testType);
               done();
             });
           });

--- a/interfaces/queryable/modifiers/sum.modifier.test.js
+++ b/interfaces/queryable/modifiers/sum.modifier.test.js
@@ -37,7 +37,7 @@ describe('Queryable Interface', function() {
     it('should sum by key and only return that key with the sum value', function(done) {
       Queryable.User.find({ where:{type: 'sum test'}, sum: ['age'] }, function(err, summed) {
         assert(!err);
-        assert(summed[0].age === 45);
+        assert.equal(summed[0].age, 45);
         done();
       });
     });
@@ -45,8 +45,8 @@ describe('Queryable Interface', function() {
     it('should sum by multiple keys and return sums of all keys', function(done) {
       Queryable.User.find({ where:{type: 'sum test'}, sum: ['age', 'percent'] }, function(err, summed) {
         assert(!err);
-        assert(summed[0].age === 45);
-        assert(summed[0].percent === 22.5);
+        assert.equal(summed[0].age, 45);
+        assert.equal(summed[0].percent, 22.5);
         done();
       });
     });
@@ -58,8 +58,8 @@ describe('Queryable Interface', function() {
         average: ['percent']
       }, function(err, summed) {
         assert(!err);
-        assert(summed[0].age === 45);
-        assert(summed[0].percent === 2.25);
+        assert.equal(summed[0].age, 45);
+        assert.equal(summed[0].percent, 2.25);
         done();
       });
     });

--- a/interfaces/scalable/crud.test.js
+++ b/interfaces/scalable/crud.test.js
@@ -61,7 +61,7 @@ describe('Load Testing', function() {
         User.create(data, next);
       }, function(err, users) {
         assert(!err);
-        assert(users.length === CONNECTIONS);
+        assert.equal(users.length, CONNECTIONS);
         done();
       });
     });

--- a/interfaces/semantic/create.test.js
+++ b/interfaces/semantic/create.test.js
@@ -13,7 +13,7 @@ describe('Semantic Interface', function() {
       Semantic.User.create({ first_name: 'Foo' }, function(err, record) {
         if (err) { console.error(err); }
         assert(!err);
-        assert(record.first_name === 'Foo');
+        assert.equal(record.first_name, 'Foo');
         done();
       });
     });
@@ -22,7 +22,7 @@ describe('Semantic Interface', function() {
       Semantic.User.create({ first_name: 'FooBar' }, function(err, user) {
         if (err) { console.error(err); }
         assert(!err);
-        assert(user.first_name === 'FooBar');
+        assert.equal(user.first_name, 'FooBar');
         assert(user.id);
         done();
       });
@@ -42,7 +42,7 @@ describe('Semantic Interface', function() {
       Semantic.User.create({ first_name: 'Foo', last_name: 'Bar' }, function(err, user) {
         if (err) { console.error(err); }
         assert(!err);
-        assert(user.fullName() === 'Foo Bar');
+        assert.equal(user.fullName(), 'Foo Bar');
         done();
       });
     });
@@ -50,7 +50,7 @@ describe('Semantic Interface', function() {
     it('should normalize undefined values to null', function(done) {
       Semantic.User.create({ first_name: 'Yezy', last_name: undefined }, function(err, user) {
         assert(!err);
-        assert(user.last_name === null);
+        assert.equal(user.last_name, null);
         done();
       });
     });
@@ -65,9 +65,9 @@ describe('Semantic Interface', function() {
       Semantic.User.create(users, function(err, users) {
         assert(!err);
         users.forEach(function(val, idx){
-          assert(users[idx].first_name === 'test_' + idx);
+          assert.equal(users[idx].first_name, 'test_' + idx);
         });
-        assert(users.length === 30, 'Expecting 30 "users", but actually got '+users.length+': '+require('util').inspect(users, false, null));
+        assert.equal(users.length, 30, 'Expecting 30 "users", but actually got '+users.length+': '+require('util').inspect(users, false, null));
         done();
       });
     });
@@ -99,8 +99,8 @@ describe('Semantic Interface', function() {
         Semantic.User.find({where : { type: testName }, sort : {first_name : 1}}, function(err, users) {
           if (err) return done(err);
           assert(!err);
-          assert(users.length === 4, 'Expecting 4 "users", but actually got '+users.length+': '+require('util').inspect(users, false, null));
-          assert(users[0].first_name === 'test_0' );
+          assert.equal(users.length, 4, 'Expecting 4 "users", but actually got '+users.length+': '+require('util').inspect(users, false, null));
+          assert.equal(users[0].first_name, 'test_0' );
           done();
         });
       });

--- a/interfaces/semantic/createEach.test.js
+++ b/interfaces/semantic/createEach.test.js
@@ -18,7 +18,7 @@ describe('Semantic Interface', function() {
       Semantic.User.createEach(usersArray, function(err, users) {
         assert(!err);
         assert(Array.isArray(users));
-        assert(users.length === 2);
+        assert.equal(users.length, 2);
         done();
       });
     });
@@ -26,7 +26,7 @@ describe('Semantic Interface', function() {
     it('should insert 2 records verififed by find', function(done) {
       Semantic.User.find({ type: 'createEach' }, function(err, users) {
         assert(!err);
-        assert(users.length === 2);
+        assert.equal(users.length, 2);
         done();
       });
     });
@@ -39,7 +39,7 @@ describe('Semantic Interface', function() {
 
       Semantic.User.createEach(usersArray, function(err, users) {
         assert(users[0].id);
-        assert(typeof users[0].fullName === 'function');
+        assert.equal(typeof users[0].fullName, 'function');
         assert(toString.call(users[0].createdAt) == '[object Date]');
         assert(toString.call(users[0].updatedAt) == '[object Date]');
         done();

--- a/interfaces/semantic/destroy.js
+++ b/interfaces/semantic/destroy.js
@@ -26,16 +26,16 @@ describe('Semantic Interface', function() {
         Semantic.User.destroy({ first_name: 'Destroy' }, function(err, records) {
           assert(!err);
           assert(Array.isArray(records));
-          assert(records.length === 1);
-          assert(records[0].first_name === 'Destroy');
-          assert(records[0].last_name === 'Test');
+          assert.equal(records.length, 1);
+          assert.equal(records[0].first_name, 'Destroy');
+          assert.equal(records[0].last_name, 'Test');
           done();
         });
       });
 
       it('should return an empty array when searched for', function(done) {
         Semantic.User.find({ first_name: 'Destroy' }, function(err, users) {
-          assert(users.length === 0);
+          assert.equal(users.length, 0);
           done();
         });
       });
@@ -72,7 +72,7 @@ describe('Semantic Interface', function() {
 
       it('should return an empty array when searched for', function(done) {
         Semantic.User.find({ first_name: 'Destroy' }, function(err, users) {
-          assert(users.length === 0);
+          assert.equal(users.length, 0);
           done();
         });
       });
@@ -105,7 +105,7 @@ describe('Semantic Interface', function() {
 
       it('should return an empty array when searched for', function(done) {
         Semantic.User.find({ first_name: 'Destroy' }, function(err, users) {
-          assert(users.length === 0);
+          assert.equal(users.length, 0);
           done();
         });
       });

--- a/interfaces/semantic/find.test.js
+++ b/interfaces/semantic/find.test.js
@@ -32,7 +32,7 @@ describe('Semantic Interface', function() {
       Semantic.User.find({ type: 'find test' }, function(err, users) {
         assert(!err);
         assert(Array.isArray(users));
-        assert(users.length === 10);
+        assert.equal(users.length, 10);
         done();
       });
     });
@@ -41,7 +41,7 @@ describe('Semantic Interface', function() {
       Semantic.User.find({ age: 10 }, function(err, users) {
         assert(!err);
         assert(Array.isArray(users));
-        assert(users.length === 1);
+        assert.equal(users.length, 1);
         done();
       });
     });
@@ -63,7 +63,7 @@ describe('Semantic Interface', function() {
       Semantic.User.find({ type: 'find test' }, function(err, users) {
         assert(!err, err);
         assert(users[0].id);
-        assert(typeof users[0].fullName === 'function');
+        assert.equal(typeof users[0].fullName, 'function');
         assert(toString.call(users[0].createdAt) == '[object Date]');
         assert(toString.call(users[0].updatedAt) == '[object Date]', 'Expected the first user in results to have a Date for its `updatedAt` value, instead, the first user looks like:' + require('util').inspect(users[0], false, null));
         done();

--- a/interfaces/semantic/findOne.test.js
+++ b/interfaces/semantic/findOne.test.js
@@ -25,7 +25,7 @@ describe('Semantic Interface', function() {
     it('should return a single record', function(done) {
       Semantic.User.findOne({ first_name: 'findOne test' }, function(err, user) {
         assert(!err);
-        assert(user.first_name === 'findOne test');
+        assert.equal(user.first_name, 'findOne test');
         done();
       });
     });
@@ -33,7 +33,7 @@ describe('Semantic Interface', function() {
     it('should return a model instance', function(done) {
       Semantic.User.findOne({ first_name: 'findOne test' }, function(err, user) {
         assert(user.id);
-        assert(typeof user.fullName === 'function');
+        assert.equal(typeof user.fullName, 'function');
         assert(toString.call(user.createdAt) == '[object Date]');
         assert(toString.call(user.updatedAt) == '[object Date]');
         done();
@@ -51,7 +51,7 @@ describe('Semantic Interface', function() {
     it('should work with just an id passed in', function(done) {
       Semantic.User.findOne(id, function(err, user) {
         assert(!err);
-        assert(user.first_name === 'findOne test');
+        assert.equal(user.first_name, 'findOne test');
         done();
       });
     });

--- a/interfaces/semantic/findOrCreate.test.js
+++ b/interfaces/semantic/findOrCreate.test.js
@@ -12,7 +12,7 @@ describe('Semantic Interface', function() {
     it('should create a new record', function(done) {
       Semantic.User.findOrCreate({ first_name: "findOrCreate()" }, { first_name: "findOrCreate()" }, function(err, user) {
         assert(!err);
-        assert(user.first_name === 'findOrCreate()');
+        assert.equal(user.first_name, 'findOrCreate()');
         done();
       });
     });
@@ -20,7 +20,7 @@ describe('Semantic Interface', function() {
     it('should return a single record', function(done) {
       Semantic.User.findOrCreate({ first_name: "findOrCreate()" }, { first_name: "findOrCreate()" }, function(err, user) {
         assert(!err);
-        assert(user.first_name === 'findOrCreate()');
+        assert.equal(user.first_name, 'findOrCreate()');
         done();
       });
     });
@@ -28,7 +28,7 @@ describe('Semantic Interface', function() {
     it('should only have a single record in the database', function(done) {
       Semantic.User.find({ first_name: 'findOrCreate()' }, function(err, users) {
         assert(!err);
-        assert(users.length === 1);
+        assert.equal(users.length, 1);
         done();
       });
     });
@@ -36,7 +36,7 @@ describe('Semantic Interface', function() {
     it('should return a model instance', function(done) {
      Semantic.User.findOrCreate({ first_name: "model findOrCreate()" }, { first_name: "model findOrCreate()", last_name: 'test' }, function(err, user) {
         assert(user.id);
-        assert(user.fullName() === 'model findOrCreate() test');
+        assert.equal(user.fullName(), 'model findOrCreate() test');
         assert(toString.call(user.createdAt) == '[object Date]');
         assert(toString.call(user.updatedAt) == '[object Date]');
         done();
@@ -46,7 +46,7 @@ describe('Semantic Interface', function() {
     it('should take search criteria as values', function(done) {
      Semantic.User.findOrCreate({ first_name: "findOrCreate()", last_name: 'search criteria' }, function(err, user) {
         assert(user.id);
-        assert(user.fullName() === 'findOrCreate() search criteria');
+        assert.equal(user.fullName(), 'findOrCreate() search criteria');
         assert(toString.call(user.createdAt) == '[object Date]');
         assert(toString.call(user.updatedAt) == '[object Date]');
         done();
@@ -58,12 +58,12 @@ describe('Semantic Interface', function() {
        { first_name: "findOrCreate()", last_name: 'array' },
        { first_name: 'Mark', last_name: 'Vegetables'}], function(err, users) {
         assert(users[0].id);
-        assert(users[0].fullName() === 'findOrCreate() array');
+        assert.equal(users[0].fullName(), 'findOrCreate() array');
         assert(toString.call(users[0].createdAt) == '[object Date]');
         assert(toString.call(users[0].updatedAt) == '[object Date]');
 
         assert(users[1].id);
-        assert(users[1].fullName() === 'Mark Vegetables');
+        assert.equal(users[1].fullName(), 'Mark Vegetables');
         assert(toString.call(users[1].createdAt) == '[object Date]');
         assert(toString.call(users[1].updatedAt) == '[object Date]');
         done();

--- a/interfaces/semantic/findOrCreateEach.test.js
+++ b/interfaces/semantic/findOrCreateEach.test.js
@@ -31,7 +31,7 @@ describe('Semantic Interface', function() {
         type: testName
       }], function(err, results) {
         assert(!err);
-        assert(results.length === 1);
+        assert.equal(results.length, 1);
         done();
       });
     });
@@ -42,14 +42,14 @@ describe('Semantic Interface', function() {
         type: testName
       }], function(err, results) {
         assert(!err);
-        assert(results.length === 1);
+        assert.equal(results.length, 1);
         done();
       });
     });
 
     it('should only have a single record for keys that exist', function(done) {
       Semantic.User.find({ first_name: 'NOT IN THE SET' }, function(err, users) {
-        assert(users.length === 1);
+        assert.equal(users.length, 1);
         done();
       });
     });
@@ -65,7 +65,7 @@ describe('Semantic Interface', function() {
       Semantic.User.findOrCreateEach(['type', 'first_name'], [{ type: testName, first_name: 'NOT IN THE SET' }], function(err, users) {
         assert(!err);
         assert(users[0].id);
-        assert(typeof users[0].fullName === 'function');
+        assert.equal(typeof users[0].fullName, 'function');
         assert(toString.call(users[0].createdAt) == '[object Date]');
         assert(toString.call(users[0].updatedAt) == '[object Date]');
         done();

--- a/interfaces/semantic/types/array.type.js
+++ b/interfaces/semantic/types/array.type.js
@@ -14,11 +14,11 @@ describe('Semantic Interface', function() {
         Semantic.User.create({ list: [0,1,2,3] }, function(err, createdRecord) {
           assert(!err);
           assert(Array.isArray(createdRecord.list));
-          assert(createdRecord.list.length === 4);
+          assert.equal(createdRecord.list.length, 4);
           Semantic.User.findOne({id: createdRecord.id}, function (err, record) {
             assert(!err);
             assert(Array.isArray(record.list));
-            assert(record.list.length === 4);
+            assert.equal(record.list.length, 4);
             done();
           });
         });

--- a/interfaces/semantic/types/array.type.js
+++ b/interfaces/semantic/types/array.type.js
@@ -14,7 +14,7 @@ describe('Semantic Interface', function() {
         Semantic.User.create({ list: [0,1,2,3] }, function(err, record) {
           assert(!err);
           assert(Array.isArray(record.list));
-          assert(record.list.length === 4);
+          assert.equal(record.list.length, 4);
           done();
         });
       });

--- a/interfaces/semantic/types/binary.type.js
+++ b/interfaces/semantic/types/binary.type.js
@@ -22,12 +22,12 @@ describe('Semantic Interface', function() {
         // store the binary thing
         Semantic.User.create({ avatar: buf }, function(err, createdRecord) {
           assert(!err, err);
-          assert(new Buffer(createdRecord.avatar).toString('utf-8') === str);
+          assert.equal(new Buffer(createdRecord.avatar).toString('utf-8'), str);
           Semantic.User.findOne({id: createdRecord.id}, function (err, record) {
               assert(!err);
               // read out the stored binary thing
               var outbuf = new Buffer(record.avatar);
-              assert(outbuf.toString('utf-8') === str);
+              assert.equal(outbuf.toString('utf-8'), str);
               done();
            });
         });

--- a/interfaces/semantic/types/binary.type.js
+++ b/interfaces/semantic/types/binary.type.js
@@ -25,7 +25,7 @@ describe('Semantic Interface', function() {
           // read out the stored binary thing
           var outbuf = new Buffer(record.avatar);
           
-          assert(outbuf.toString('utf-8') === str);
+          assert.equal(outbuf.toString('utf-8'), str);
           done();
         });
       });

--- a/interfaces/semantic/types/boolean.type.js
+++ b/interfaces/semantic/types/boolean.type.js
@@ -13,10 +13,10 @@ describe('Semantic Interface', function() {
       it('should store proper boolean value', function(done) {
         Semantic.User.create({ status: true }, function (err, createdRecord) {
           assert(!err);
-          assert(createdRecord.status === true);
+          assert.equal(createdRecord.status, true);
           Semantic.User.findOne({id: createdRecord.id}, function (err, record) {
             assert(!err);
-            assert(record.status === true);
+            assert.equal(record.status, true);
             done();
           });
         });

--- a/interfaces/semantic/types/boolean.type.js
+++ b/interfaces/semantic/types/boolean.type.js
@@ -13,7 +13,7 @@ describe('Semantic Interface', function() {
       it('should store proper boolean value', function(done) {
         Semantic.User.create({ status: true }, function(err, record) {
           assert(!err);
-          assert(record.status === true);
+          assert.equal(record.status, true);
           done();
         });
       });

--- a/interfaces/semantic/types/date.type.js
+++ b/interfaces/semantic/types/date.type.js
@@ -16,12 +16,12 @@ describe('Semantic Interface', function() {
         Semantic.User.create({ dob: date }, function(err, createdRecord) {
           assert(!err);
           var createdDate = Date.parse(new Date(createdRecord.dob));
-          assert(origDate === createdDate);
+          assert.equal(origDate, createdDate);
           Semantic.User.findOne({id: createdRecord.id}, function (err, record) {
             assert(!err);
             // Convert both dates to unix timestamps
             var resultDate = Date.parse(new Date(record.dob));
-            assert(origDate === resultDate);
+            assert.equal(origDate, resultDate);
             done();
           });
         });

--- a/interfaces/semantic/types/date.type.js
+++ b/interfaces/semantic/types/date.type.js
@@ -19,7 +19,7 @@ describe('Semantic Interface', function() {
           var origDate = Date.parse(date);
           var resultDate = Date.parse(new Date(record.dob));
 
-          assert(origDate === resultDate);
+          assert.equal(origDate, resultDate);
           done();
         });
       });

--- a/interfaces/semantic/types/float.type.js
+++ b/interfaces/semantic/types/float.type.js
@@ -13,10 +13,10 @@ describe('Semantic Interface', function() {
       it('should store proper float value', function(done) {
         Semantic.User.create({ percent: 0.001 }, function(err, createdRecord) {
           assert(!err);
-          assert(createdRecord.percent === 0.001);
+          assert.equal(createdRecord.percent, 0.001);
           Semantic.User.findOne({id: createdRecord.id}, function(err, record) {
             assert(!err);
-            assert(record.percent === 0.001);
+            assert.equal(record.percent, 0.001);
             done();
           });
         });

--- a/interfaces/semantic/types/float.type.js
+++ b/interfaces/semantic/types/float.type.js
@@ -13,7 +13,7 @@ describe('Semantic Interface', function() {
       it('should store proper float value', function(done) {
         Semantic.User.create({ percent: 0.001 }, function(err, record) {
           assert(!err);
-          assert(record.percent === 0.001);
+          assert.equal(record.percent, 0.001);
           done();
         });
       });

--- a/interfaces/semantic/types/integer.type.js
+++ b/interfaces/semantic/types/integer.type.js
@@ -13,10 +13,10 @@ describe('Semantic Interface', function() {
       it('should store proper integer', function(done) {
         Semantic.User.create({ age: 27 }, function (err, createdRecord) {
           assert(!err);
-          assert(createdRecord.age === 27);
+          assert.equal(createdRecord.age, 27);
           Semantic.User.findOne({id: createdRecord.id}, function (err, record) {
             assert(!err);
-            assert(record.age === 27);
+            assert.equal(record.age, 27);
             done();
           });
         });

--- a/interfaces/semantic/types/integer.type.js
+++ b/interfaces/semantic/types/integer.type.js
@@ -13,7 +13,7 @@ describe('Semantic Interface', function() {
       it('should store proper integer', function(done) {
         Semantic.User.create({ age: 27 }, function(err, record) {
           assert(!err);
-          assert(record.age === 27);
+          assert.equal(record.age, 27);
           done();
         });
       });

--- a/interfaces/semantic/types/json.type.js
+++ b/interfaces/semantic/types/json.type.js
@@ -13,8 +13,8 @@ describe('Semantic Interface', function() {
       it('should store proper object value', function(done) {
         Semantic.User.create({ obj: {foo: 'bar'} }, function(err, record) {
           assert(!err);
-          assert(record.obj === Object(record.obj));
-          assert(record.obj.foo === 'bar');
+          assert.equal(record.obj, Object(record.obj));
+          assert.equal(record.obj.foo, 'bar');
           done();
         });
       });

--- a/interfaces/semantic/types/json.type.js
+++ b/interfaces/semantic/types/json.type.js
@@ -13,12 +13,12 @@ describe('Semantic Interface', function() {
       it('should store proper object value', function(done) {
         Semantic.User.create({ obj: {foo: 'bar'} }, function(err, createdRecord) {
           assert(!err);
-          assert(createdRecord.obj === Object(createdRecord.obj));
-          assert(createdRecord.obj.foo === 'bar');
+          assert.equal(createdRecord.obj, Object(createdRecord.obj));
+          assert.equal(createdRecord.obj.foo, 'bar');
           Semantic.User.findOne({id: createdRecord.id}, function (err, record) {
             assert(!err);
-            assert(record.obj === Object(record.obj));
-            assert(record.obj.foo === 'bar');
+            assert.equal(record.obj, Object(record.obj));
+            assert.equal(record.obj.foo, 'bar');
             done();
           });
         });

--- a/interfaces/semantic/types/string.type.js
+++ b/interfaces/semantic/types/string.type.js
@@ -13,7 +13,7 @@ describe('Semantic Interface', function() {
       it('should store proper string value', function(done) {
         Semantic.User.create({ first_name: 'Foo' }, function(err, record) {
           assert(!err);
-          assert(record.first_name === 'Foo');
+          assert.equal(record.first_name, 'Foo');
           done();
         });
       });

--- a/interfaces/semantic/types/string.type.js
+++ b/interfaces/semantic/types/string.type.js
@@ -13,10 +13,10 @@ describe('Semantic Interface', function() {
       it('should store proper string value', function(done) {
         Semantic.User.create({ first_name: 'Foo' }, function(err, createdRecord) {
           assert(!err);
-          assert(createdRecord.first_name === 'Foo');
+          assert.equal(createdRecord.first_name, 'Foo');
           Semantic.User.findOne({id: createdRecord.id}, function (err, record) {
             assert(!err);
-            assert(record.first_name === 'Foo');
+            assert.equal(record.first_name, 'Foo');
             done();
           });
         });

--- a/interfaces/semantic/update.test.js
+++ b/interfaces/semantic/update.test.js
@@ -52,8 +52,8 @@ describe('Semantic Interface', function() {
         Semantic.User.update({ type: 'update' }, { last_name: 'updated' }, function(err, users) {
           assert(!err);
           assert(Array.isArray(users));
-          assert(users.length === 10);
-          assert(users[0].last_name === 'updated');
+          assert.equal(users.length, 10);
+          assert.equal(users[0].last_name, 'updated');
           done();
         });
       });
@@ -62,8 +62,8 @@ describe('Semantic Interface', function() {
        Semantic. User.update({ type: 'update' }, { last_name: 'updated again' }).exec(function(err, users) {
           assert(!err);
           assert(users[0].id);
-          assert(users[0].first_name.indexOf('update_user') === 0);
-          assert(users[0].last_name === 'updated again');
+          assert.equal(users[0].first_name.indexOf('update_user'), 0);
+          assert.equal(users[0].last_name, 'updated again');
           assert(toString.call(users[0].createdAt) == '[object Date]');
           assert(toString.call(users[0].updatedAt) == '[object Date]');
           done();
@@ -73,7 +73,7 @@ describe('Semantic Interface', function() {
       it('should work with just an ID passed in', function(done) {
         Semantic.User.update(id, { first_name: 'foo' }).sort('first_name').exec(function(err, users) {
           assert(!err);
-          assert(users[0].first_name === 'foo');
+          assert.equal(users[0].first_name, 'foo');
           done();
         });
       });
@@ -81,8 +81,8 @@ describe('Semantic Interface', function() {
       it('should work with an empty object', function(done) {
         Semantic.User.update({}, { type: 'update all' }, function(err, users) {
           assert(!err);
-          assert(users.length === 10);
-          assert(users[0].type === 'update all');
+          assert.equal(users.length, 10);
+          assert.equal(users[0].type, 'update all');
           done();
         });
       });
@@ -90,7 +90,7 @@ describe('Semantic Interface', function() {
       it('should work with null values', function(done) {
         Semantic.User.update(id, { age: null }, function(err, users) {
           assert(!err);
-          assert(users[0].age === null);
+          assert.equal(users[0].age, null);
           done();
         });
       });
@@ -130,9 +130,9 @@ describe('Semantic Interface', function() {
       it('should allow the record to be found', function(done) {
         Semantic.User.find({ type: 'updateFind' }, function(err, users) {
           assert(!err);
-          assert(users.length === 2);
-          assert(users[0].last_name === 'Updated Find');
-          assert(users[1].last_name === 'Updated Find');
+          assert.equal(users.length, 2);
+          assert.equal(users[0].last_name, 'Updated Find');
+          assert.equal(users[1].last_name, 'Updated Find');
           done();
         });
       });


### PR DESCRIPTION
Fixes #30 by replacing instances of `assert(a === b)` for `assert.equal(a, b)`. For those curious this was done with `sed`: 

``` bash
find . -name '*.js' -type f -print0 | xargs -0 sed -i '' 's/assert(\([^|&]*\) ===\([^|&]*\))/assert.equal(\1,\2)/g'
```

I've checked the number of tests ran was the same before and after the change and visually inspected all changes so we should be good.

Original issue:
> Specifically, `assert.equal` should always be used with strings. Some string comparisons will fail triple-equality check. I've run into this in getting the tests to pass in the couch adapter.
> 
> From a UX perspective, the methods will produce more helpful and descriptive failure messages.

cc: @tjwebb, @devinivy 