### PR TITLE
Adds tests for SELECT modifier

### DIFF
--- a/interfaces/queryable/modifiers/select.modifier.test.js
+++ b/interfaces/queryable/modifiers/select.modifier.test.js
@@ -1,0 +1,93 @@
+var assert = require('assert'),
+    _ = require('lodash');
+
+describe('Queryable Interface', function() {
+
+  describe('SELECT Query Modifier', function() {
+
+    /////////////////////////////////////////////////////
+    // TEST SETUP
+    ////////////////////////////////////////////////////
+
+    before(function(done) {
+
+      // Insert 1 Users
+      var user = {
+          first_name: 'select_user',
+          last_name: 'select_name',
+          email: 'select_email',
+          title: 'select_title',
+          age: 30,
+          type: 'select test'
+        };
+
+      Queryable.User.create(user, function(err, model) {
+        if(err) return done(err);
+        done();
+      });
+    });
+
+    /////////////////////////////////////////////////////
+    // TEST METHODS
+    ////////////////////////////////////////////////////
+
+    it('should return a record with a single field first_name', function(done) {
+      Queryable.User.find({ where: { type: 'select test' }, select: ['first_name'] }, function(err, users) {
+        assert(!err);
+        var user = users[0];
+        assert.equal(user.first_name, 'select_user');
+        assert.equal(user.last_name, undefined);
+        assert.equal(user.email, undefined);
+        assert.equal(user.title, undefined);
+        assert.equal(user.age, undefined);
+        assert.equal(user.type, undefined);
+        assert.equal(user.dob, undefined);
+        done();
+      });
+    });
+    
+    it('should return a record with a single field first_name (findOne)', function(done) {
+      Queryable.User.findOne({ where: { type: 'select test' }, select: ['first_name'] }, function(err, user) {
+        assert(!err);
+        assert.equal(user.first_name, 'select_user');
+        assert.equal(user.last_name, undefined);
+        assert.equal(user.email, undefined);
+        assert.equal(user.title, undefined);
+        assert.equal(user.age, undefined);
+        assert.equal(user.type, undefined);
+        assert.equal(user.dob, undefined);
+        done();
+      });
+    });
+
+    it('should return a record with multiple fields', function(done) {
+      Queryable.User.find({ where: { type: 'select test' }, select: ['first_name', 'age'] }, function(err, users) {
+        assert(!err);
+        var user = users[0];
+        assert.equal(user.first_name, 'select_user');
+        assert.equal(user.last_name, undefined);
+        assert.equal(user.email, undefined);
+        assert.equal(user.title, undefined);
+        assert.strictEqual(user.age, 30);
+        assert.equal(user.type, undefined);
+        assert.equal(user.dob, undefined);
+        done();
+      });
+    });
+
+    it('in absence of SELECT modifier should return a record with all fields', function(done) {
+      Queryable.User.find({ where: { type: 'select test' } }, function(err, users) {
+        assert(!err);
+        var user = users[0];
+        assert.equal(user.first_name, 'select_user');
+        assert.equal(user.last_name, 'select_name');
+        assert.equal(user.email, 'select_email');
+        assert.equal(user.title, 'select_title');
+        assert.strictEqual(user.age, 30);
+        assert.equal(user.type, 'select test');
+        done();
+      });
+    });
+
+  });
+});

--- a/interfaces/queryable/modifiers/select.modifier.test.js
+++ b/interfaces/queryable/modifiers/select.modifier.test.js
@@ -1,6 +1,10 @@
 var assert = require('assert'),
     _ = require('lodash');
 
+function assertNotProperty(obj, prop){
+  assert(prop in obj === false, 'property [' + prop + '] should not exist, but it exists and has value: ' + obj[prop]);
+}
+
 describe('Queryable Interface', function() {
 
   describe('SELECT Query Modifier', function() {
@@ -36,12 +40,12 @@ describe('Queryable Interface', function() {
         assert(!err);
         var user = users[0];
         assert.equal(user.first_name, 'select_user');
-        assert.equal(user.last_name, undefined);
-        assert.equal(user.email, undefined);
-        assert.equal(user.title, undefined);
-        assert.equal(user.age, undefined);
-        assert.equal(user.type, undefined);
-        assert.equal(user.dob, undefined);
+        assertNotProperty(user, 'last_name');
+        assertNotProperty(user, 'email');
+        assertNotProperty(user, 'title');
+        assertNotProperty(user, 'age');
+        assertNotProperty(user, 'type');
+        assertNotProperty(user, 'dob');
         done();
       });
     });
@@ -50,12 +54,12 @@ describe('Queryable Interface', function() {
       Queryable.User.findOne({ where: { type: 'select test' }, select: ['first_name'] }, function(err, user) {
         assert(!err);
         assert.equal(user.first_name, 'select_user');
-        assert.equal(user.last_name, undefined);
-        assert.equal(user.email, undefined);
-        assert.equal(user.title, undefined);
-        assert.equal(user.age, undefined);
-        assert.equal(user.type, undefined);
-        assert.equal(user.dob, undefined);
+        assertNotProperty(user, 'last_name');
+        assertNotProperty(user, 'email');
+        assertNotProperty(user, 'title');
+        assertNotProperty(user, 'age');
+        assertNotProperty(user, 'type');
+        assertNotProperty(user, 'dob');
         done();
       });
     });
@@ -65,12 +69,12 @@ describe('Queryable Interface', function() {
         assert(!err);
         var user = users[0];
         assert.equal(user.first_name, 'select_user');
-        assert.equal(user.last_name, undefined);
-        assert.equal(user.email, undefined);
-        assert.equal(user.title, undefined);
+        assertNotProperty(user, 'last_name');
+        assertNotProperty(user, 'email');
+        assertNotProperty(user, 'title');
         assert.strictEqual(user.age, 30);
-        assert.equal(user.type, undefined);
-        assert.equal(user.dob, undefined);
+        assertNotProperty(user, 'type');
+        assertNotProperty(user, 'dob');
         done();
       });
     });


### PR DESCRIPTION
As mentioned in https://github.com/balderdashy/waterline/issues/366#issuecomment-102396946 this PR adds tests for the SELECT modifier.

Unfortunately, as happened previously on PR #53 sails-mongo is blocking this from being merged as it breaks the tests: https://travis-ci.org/balderdashy/waterline-adapter-tests/jobs/62718504#L545.

Remaining task:
- [x] Fix sails-mongo balderdashy/sails-mongo#281