### PR TITLE
test .update() when missing required fields

### DIFF
--- a/interfaces/semantic/support/bootstrap.js
+++ b/interfaces/semantic/support/bootstrap.js
@@ -9,7 +9,8 @@ var assert = require('assert');
 
 // Require Fixtures
 var fixtures = {
-  UserFixture: require('./fixtures/crud.fixture')
+  UserFixture: require('./fixtures/crud.fixture'),
+  ThingFixture: require('./fixtures/validations.fixture')
 };
 
 

--- a/interfaces/semantic/support/fixtures/validations.fixture.js
+++ b/interfaces/semantic/support/fixtures/validations.fixture.js
@@ -1,0 +1,27 @@
+/**
+ * Dependencies
+ */
+
+var Waterline = require('waterline');
+
+module.exports = Waterline.Collection.extend({
+
+  identity: 'thing',
+  tableName: 'thingTable',
+  connection: 'semantic',
+
+  attributes: {
+    name: {
+      type: 'string',
+      required: true
+    },
+    age: {
+      type: 'integer',
+      required: true,
+      min: 5,
+      max: 20
+    },
+    description: 'string'
+  }
+
+});

--- a/interfaces/semantic/update.test.js
+++ b/interfaces/semantic/update.test.js
@@ -25,7 +25,7 @@ describe('Semantic Interface', function() {
       // TEST SETUP
       ////////////////////////////////////////////////////
 
-      var id;
+      var id, thingId;
 
       before(function(done) {
 
@@ -39,7 +39,11 @@ describe('Semantic Interface', function() {
         Semantic.User.createEach(users, function(err, users) {
           if(err) return done(err);
           id = users[0].id.toString();
-          done();
+          Semantic.Thing.create({ name: 'The Thing', description: 'A thing', age: 10 }, function(err, thing) {
+            if(err) return done(err);
+            thingId = thing.id;
+            done();
+          });
         });
       });
 
@@ -91,6 +95,17 @@ describe('Semantic Interface', function() {
         Semantic.User.update(id, { age: null }, function(err, users) {
           assert(!err);
           assert.strictEqual(users[0].age, null);
+          done();
+        });
+      });
+      
+      it('should update model attributes without supplying required fields', function(done) {
+        Semantic.Thing.update(thingId, { description: 'An updated thing' }, function(err, things) {
+          assert(!err);
+          assert(Array.isArray(things));
+          assert.strictEqual(things.length, 1);
+          assert.equal(things[0].id, thingId);
+          assert.equal(things[0].description, 'An updated thing');
           done();
         });
       });


### PR DESCRIPTION
Related to balderdashy/waterline#1003.

Strictly speaking this test can be seen as being redundant since [waterline/test/unit/query/query.update.js#L48-L53](https://github.com/balderdashy/waterline/blob/4653f8a18016d2bcde9a70c90dd63a7c69381935/test/unit/query/query.update.js#L48-L53) covers this scenario. The key difference is that in this case real adapters are used.

cc: @devinivy, @kvindasAB