### PR TITLE
Test `afterUpdate` values (failing test)

### DIFF
--- a/interfaces/semantic/support/fixtures/crud.fixture.js
+++ b/interfaces/semantic/support/fixtures/crud.fixture.js
@@ -3,6 +3,7 @@
  */
 
 var Waterline = require('waterline');
+var _ = require('lodash');
 
 module.exports = Waterline.Collection.extend({
 
@@ -39,7 +40,13 @@ module.exports = Waterline.Collection.extend({
     obj: 'json',
     fullName: function() {
       return this.first_name + ' ' + this.last_name;
-    }
+    },
+  },
+  
+  afterUpdate: function (values, cb) {
+    var afterUpdateValues = _.cloneDeep(values);
+    values.afterUpdateValues = afterUpdateValues;
+    cb();
   }
 
 });

--- a/interfaces/semantic/types/array.type.js
+++ b/interfaces/semantic/types/array.type.js
@@ -9,16 +9,39 @@ describe('Semantic Interface', function() {
       /////////////////////////////////////////////////////
       // TEST METHODS
       ////////////////////////////////////////////////////
+      
+      function assertArrayMatches(actual, expected){
+        assert(Array.isArray(actual));
+        assert.strictEqual(actual.length, expected.length);
+        assert.deepEqual(actual, expected);
+      }
+      
+      var id;
 
       it('should store proper array value', function(done) {
-        Semantic.User.create({ list: [0,1,2,3] }, function(err, createdRecord) {
+        var original = [0,1,2,3];
+        Semantic.User.create({ list: original }, function(err, createdRecord) {
+          id = createdRecord.id;
           assert(!err);
-          assert(Array.isArray(createdRecord.list));
-          assert.strictEqual(createdRecord.list.length, 4);
+          assertArrayMatches(createdRecord.list, original);
           Semantic.User.findOne({id: createdRecord.id}, function (err, record) {
             assert(!err);
-            assert(Array.isArray(record.list));
-            assert.strictEqual(record.list.length, 4);
+            assertArrayMatches(record.list, original);
+            done();
+          });
+        });
+      });
+      
+      it('should update proper array value', function(done) {
+        var original = [0,1,2];
+        Semantic.User.update(id, { list: original }, function(err, updatedRecords) {
+          var updatedRecord = updatedRecords[0];
+          assert(!err);
+          assertArrayMatches(updatedRecord.list, original);
+          assertArrayMatches(updatedRecord.afterUpdateValues.list, original);
+          Semantic.User.findOne({id: updatedRecord.id}, function (err, record) {
+            assert(!err);
+            assertArrayMatches(record.list, original);
             done();
           });
         });


### PR DESCRIPTION
Adds failing test for balderdashy/waterline#698 and should replace balderdashy/waterline#971.

As reported in balderdashy/waterline#698, when a record is updated in sails-mysql, the arrays passed to `afterUpdate` lifecycle callback are transformed to strings. This test exposes that, as you can see here: https://travis-ci.org/dmarcelino/waterline-adapter-tests/jobs/62814934#L550

Remaining task:
- [ ] Fix sails-mysql

:no_entry:  **Do not merge yet, this breaks sails-mysql tests** :no_entry: 