### PR TITLE
Two minor suggestions regarding #64

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -28,7 +28,10 @@ module.exports = function(options) {
   
   // cross-adapter is a special case since it requires a clean test cache for
   // running existing associations tests
-  var crossAdapterIndex = this.features.indexOf('cross-adapter');
+  var crossAdapterIndex = this.features.indexOf('crossAdapter');
+  if (crossAdapterIndex === -1) {
+    crossAdapterIndex = this.features.indexOf('cross-adapter');
+  }
   var runCrossAdapterTests;
   if(crossAdapterIndex >= 0){
     this.features.splice(crossAdapterIndex, 1);

--- a/test/integration/runner.js
+++ b/test/integration/runner.js
@@ -40,6 +40,10 @@ catch (e) {
 console.info('Testing `' + package.name + '`, a Sails adapter.');
 console.info('Running `waterline-adapter-tests` against ' + interfaces.length + ' interfaces...');
 console.info('( ' + interfaces.join(', ') + ' )');
+if (features.length) {
+  console.info('and against ' + features.length + ' feature tests...');
+  console.info('( ' + features.join(', ') + ' )');
+}
 console.log();
 console.log('Latest draft of Waterline adapter interface spec:');
 console.info('https://github.com/balderdashy/sails-docs/blob/master/contributing/adapter-specification.md');


### PR DESCRIPTION
The number of interfaces each adapter is tested against is printed before the tests start. This PR also adds the number of features being tested.

In this project camelCase is the standard file naming convention. Since feature test file paths are derived from the feature names it makes sense to standardize feature names in camelCase as well. This means the `cross-adapter` feature should become `crossAdapter`. The solution proposed here is backwards compatible.