### PR TITLE
Integration: throw error if sails-redis fails

### DIFF
--- a/test/integration/config/sails-redis.json
+++ b/test/integration/config/sails-redis.json
@@ -5,5 +5,5 @@
     "schema": true,
     "poolSize": 1
   },
-  "returnZeroOnError": true
+  "returnZeroOnError": false
 }


### PR DESCRIPTION
Given that sails-redis now passes the integration tests (balderdashy/sails-redis#67), let the build fail if the opposite happens.