### PR TITLE
Test that `originalError` is set for unique keys

### DIFF
--- a/features/unique/core/unique.test.js
+++ b/features/unique/core/unique.test.js
@@ -72,6 +72,13 @@ describe('unique attribute feature', function() {
     });
   });
 
+  it('should attach the original error when creating with a duplicate value', function(done) {
+    UniqueModel.create({ email: email0, type: 'unique' }, function(err, records) {
+      assert.strictEqual(err.code, 'E_VALIDATION');
+      assert.ok(err.originalError);
+    });
+  });
+
   it('should error when updating with a duplicate value', function(done) {
     UniqueModel.update(id1, { email: email0 }).exec(function(err, records) {
       assert(err);


### PR DESCRIPTION
It's set for WLError, but at least one library clobbers the original error
message when creating a WLValidationError. Test that this property exists.

Um, a little uncertain about the best practice here - I only use/care about one library, and I don't expect this to be implemented anywhere else, though I believe it should be, obviously.

Specifically: sails-postgresql currently creates its own error and discards the native Postgres error when a uniqueness check fails. I would like to keep the Postgres error around as `originalError`, the same way it is for any non-23505 && non-"Key ... already exists" error message. This passes for the sails-postgresql adapter (though many other tests fail; haven't looked into why).