### PR TITLE
added tests for "compositeUnique" feature

### DIFF
--- a/features/compositeUnique/core/compositeUnique.test.js
+++ b/features/compositeUnique/core/compositeUnique.test.js
@@ -1,0 +1,67 @@
+var assert = require('assert');
+var _ = require('lodash');
+
+describe('compositeUnique feature', function () {
+  var Waterline = require('waterline');
+  var defaults = { migrate: 'alter' };
+  var waterline;
+
+  var Fixture = require('./../support/fixture.js');
+  var Model;
+
+
+  before(function(done) {
+    waterline = new Waterline();
+    waterline.loadCollection(Fixture);
+
+    var connections = { compositeUniqueConnection: _.clone(Connections.test) };
+
+    Adapter.teardown('compositeUniqueConnection', function adapterTeardown(){
+      waterline.initialize({ adapters: { wl_tests: Adapter }, connections: connections, defaults: defaults }, function(err, ontology) {
+        if(err) return done(err);
+        Model = ontology.collections['compositeunique'];
+        done();
+      });
+    });
+  });
+  after(function(done) {
+    if(!Adapter.hasOwnProperty('drop')) {
+      waterline.teardown(done);
+    } else {
+      Model.drop(function(err1) {
+        waterline.teardown(function(err2) {
+          return done(err1 || err2);
+        });
+      });
+    }
+  });
+
+  it('should insert unique values', function (done) {
+    var records = [
+      { name: '1st', uniqueOne: 'foo', uniqueTwo: 'bar' },
+      { name: '2nd', uniqueOne: 'foo', uniqueTwo: 'baz' },
+      { name: '3rd', uniqueOne: 'bar', uniqueTwo: 'bar' },
+      { name: '4th', uniqueOne: 'bar', uniqueTwo: 'baz' }
+    ];
+
+    Model.create(records)
+      .then(function (records) {
+        assert(records.length, 4);
+        done();
+      })
+      .catch(done)
+  })
+  it('should enforce composite uniqueness', function (done) {
+    var records = [
+      { name: '5th', uniqueOne: 'foo', uniqueTwo: 'bar' }
+    ];
+    Model.create(records)
+      .then(function (records) {
+        done(new Error('should not have inserted unique records, but did anyway'));
+      })
+      .catch(function (err) {
+        assert(err)
+        done();
+      })
+  })
+})

--- a/features/compositeUnique/support/fixture.js
+++ b/features/compositeUnique/support/fixture.js
@@ -1,0 +1,29 @@
+var Waterline = require('waterline');
+
+module.exports = Waterline.Collection.extend({
+
+  identity: 'compositeUnique',
+  tableName: 'compositeUniqueTable',
+  connection: 'compositeUniqueConnection',
+
+  attributes: {
+    name: 'string',
+    uniqueOne: {
+      type: 'string',
+      unique: {
+        unique: false,
+        composite: [ 'uniqueTwo' ]
+      }
+    },
+
+    uniqueTwo: {
+      type: 'string',
+      unique: {
+        unique: false,
+        composite: [ 'uniqueOne' ]
+      }
+    }
+  }
+
+});
+


### PR DESCRIPTION
Tests the ability for an adapter to define one or more composite unique constraints.

An example attribute definition is here: https://github.com/tjwebb/waterline-adapter-tests/blob/a7168909acc540d88e76de6471dd8393039673d4/features/compositeUnique/support/fixture.js#L11-L25