### PR TITLE
added tests for "compositePrimaryKey" feature

### DIFF
--- a/features/compositePrimaryKey/core/compositePrimaryKey.test.js
+++ b/features/compositePrimaryKey/core/compositePrimaryKey.test.js
@@ -1,0 +1,67 @@
+var assert = require('assert');
+var _ = require('lodash');
+
+describe('compositePrimaryKey feature', function () {
+  var Waterline = require('waterline');
+  var defaults = { migrate: 'alter' };
+  var waterline;
+
+  var Fixture = require('../support/fixture.js');
+  var Model;
+
+  before(function(done) {
+    waterline = new Waterline();
+    waterline.loadCollection(Fixture);
+
+    var connections = { compositePrimaryKeyConnection: _.clone(Connections.test) };
+
+    Adapter.teardown('compositePrimaryKeyConnection', function adapterTeardown(){
+      waterline.initialize({ adapters: { wl_tests: Adapter }, connections: connections, defaults: defaults }, function(err, ontology) {
+        if(err) return done(err);
+        Model = ontology.collections['compositeprimarykey'];
+        done();
+      });
+    });
+  });
+  after(function(done) {
+    if(!Adapter.hasOwnProperty('drop')) {
+      waterline.teardown(done);
+    } else {
+      Model.drop(function(err1) {
+        waterline.teardown(function(err2) {
+          return done(err1 || err2);
+        });
+      });
+    }
+    done()
+  });
+
+  it('should insert unique records', function (done) {
+    var records = [
+      { name: '1st', pkOne: 1, pkTwo: 'bar' },
+      { name: '2nd', pkOne: 2, pkTwo: 'baz' },
+      { name: '3rd', pkOne: 3, pkTwo: 'bar' },
+      { name: '4th', pkOne: 4, pkTwo: 'baz' }
+    ];
+
+    Model.create(records)
+      .then(function (records) {
+        assert(records.length, 4);
+        done();
+      })
+      .catch(done)
+  })
+  it('should enforce composite uniqueness', function (done) {
+    var records = [
+      { name: '5th', pkOne: 1, pkTwo: 'bar' }
+    ];
+    Model.create(records)
+      .then(function (records) {
+        done(new Error('should not have inserted unique records, but did anyway'));
+      })
+      .catch(function (err) {
+        assert(err)
+        done();
+      })
+  })
+})

--- a/features/compositePrimaryKey/support/fixture.js
+++ b/features/compositePrimaryKey/support/fixture.js
@@ -1,0 +1,24 @@
+var Waterline = require('waterline');
+
+module.exports = Waterline.Collection.extend({
+
+  identity: 'compositePrimaryKey',
+  tableName: 'compositePrimaryKeyTable',
+  connection: 'compositePrimaryKeyConnection',
+  autoPK: false,
+
+  attributes: {
+    name: 'string',
+    pkOne: {
+      type: 'integer',
+      primaryKey: true
+    },
+
+    pkTwo: {
+      type: 'string',
+      primaryKey: true
+    }
+  }
+
+});
+

--- a/features/compositeUnique/core/compositeUnique.test.js
+++ b/features/compositeUnique/core/compositeUnique.test.js
@@ -1,0 +1,67 @@
+var assert = require('assert');
+var _ = require('lodash');
+
+describe('compositeUnique feature', function () {
+  var Waterline = require('waterline');
+  var defaults = { migrate: 'alter' };
+  var waterline;
+
+  var Fixture = require('./../support/fixture.js');
+  var Model;
+
+
+  before(function(done) {
+    waterline = new Waterline();
+    waterline.loadCollection(Fixture);
+
+    var connections = { compositeUniqueConnection: _.clone(Connections.test) };
+
+    Adapter.teardown('compositeUniqueConnection', function adapterTeardown(){
+      waterline.initialize({ adapters: { wl_tests: Adapter }, connections: connections, defaults: defaults }, function(err, ontology) {
+        if(err) return done(err);
+        Model = ontology.collections['compositeunique'];
+        done();
+      });
+    });
+  });
+  after(function(done) {
+    if(!Adapter.hasOwnProperty('drop')) {
+      waterline.teardown(done);
+    } else {
+      Model.drop(function(err1) {
+        waterline.teardown(function(err2) {
+          return done(err1 || err2);
+        });
+      });
+    }
+  });
+
+  it('should insert unique values', function (done) {
+    var records = [
+      { name: '1st', uniqueOne: 'foo', uniqueTwo: 'bar' },
+      { name: '2nd', uniqueOne: 'foo', uniqueTwo: 'baz' },
+      { name: '3rd', uniqueOne: 'bar', uniqueTwo: 'bar' },
+      { name: '4th', uniqueOne: 'bar', uniqueTwo: 'baz' }
+    ];
+
+    Model.create(records)
+      .then(function (records) {
+        assert(records.length, 4);
+        done();
+      })
+      .catch(done)
+  })
+  it('should enforce composite uniqueness', function (done) {
+    var records = [
+      { name: '5th', uniqueOne: 'foo', uniqueTwo: 'bar' }
+    ];
+    Model.create(records)
+      .then(function (records) {
+        done(new Error('should not have inserted unique records, but did anyway'));
+      })
+      .catch(function (err) {
+        assert(err)
+        done();
+      })
+  })
+})

--- a/features/compositeUnique/support/fixture.js
+++ b/features/compositeUnique/support/fixture.js
@@ -1,0 +1,29 @@
+var Waterline = require('waterline');
+
+module.exports = Waterline.Collection.extend({
+
+  identity: 'compositeUnique',
+  tableName: 'compositeUniqueTable',
+  connection: 'compositeUniqueConnection',
+
+  attributes: {
+    name: 'string',
+    uniqueOne: {
+      type: 'string',
+      unique: {
+        unique: false,
+        composite: [ 'uniqueTwo' ]
+      }
+    },
+
+    uniqueTwo: {
+      type: 'string',
+      unique: {
+        unique: false,
+        composite: [ 'uniqueOne' ]
+      }
+    }
+  }
+
+});
+


### PR DESCRIPTION
Tests the ability for an adapter to define a composite primary key on a table.

Example usage here: https://github.com/tjwebb/waterline-adapter-tests/blob/feature-compositePrimaryKey/features/compositePrimaryKey/support/fixture.js#L12-L20